### PR TITLE
chore: CODEOWNERS 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS
+# 아래 규칙은 마지막 매칭이 우선합니다. 중요 경로는 아래쪽에 둡니다.
+# 중요 경로가 변경된 PR은 일반 승인 1명 + 코드오너 승인 1명 = 2명이 필요합니다.
+
+# 기본: 팀 전체
+*                               @depromeet/18th_team6_android
+
+# 빌드 / 의존성
+*.gradle                        @depromeet/18th_team6_android
+*.gradle.kts                    @depromeet/18th_team6_android
+gradle/                         @depromeet/18th_team6_android
+gradle.properties               @depromeet/18th_team6_android
+settings.gradle*                @depromeet/18th_team6_android
+buildSrc/                       @depromeet/18th_team6_android
+gradle/libs.versions.toml       @depromeet/18th_team6_android
+**/proguard-rules.pro           @depromeet/18th_team6_android
+
+# 매니페스트 / 런타임 설정
+**/AndroidManifest.xml          @depromeet/18th_team6_android
+
+# CI / GitHub 설정
+.github/workflows/              @depromeet/18th_team6_android
+.github/CODEOWNERS              @depromeet/18th_team6_android
+
+# 코드 품질 설정
+.editorconfig                   @depromeet/18th_team6_android
+**/detekt.yml                   @depromeet/18th_team6_android

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,33 @@
 # CODEOWNERS
 # 아래 규칙은 마지막 매칭이 우선합니다. 중요 경로는 아래쪽에 둡니다.
 # 중요 경로가 변경된 PR은 일반 승인 1명 + 코드오너 승인 1명 = 2명이 필요합니다.
+#
+# 팀원 (2026 디프만 18기 Android 6팀)
+#   @thirfir    - 이상일 (파트장)
+#   @Ddudduu    - 임지원
+#   @elaus00    - 최지우
+#   @Junhee8649 - 이준희
 
-# 기본: 팀 전체
-*                               @depromeet/18th_team6_android
+# 기본: 팀원 전체
+*                               @thirfir @Ddudduu @elaus00 @Junhee8649
 
 # 빌드 / 의존성
-*.gradle                        @depromeet/18th_team6_android
-*.gradle.kts                    @depromeet/18th_team6_android
-gradle/                         @depromeet/18th_team6_android
-gradle.properties               @depromeet/18th_team6_android
-settings.gradle*                @depromeet/18th_team6_android
-buildSrc/                       @depromeet/18th_team6_android
-gradle/libs.versions.toml       @depromeet/18th_team6_android
-**/proguard-rules.pro           @depromeet/18th_team6_android
+*.gradle                        @thirfir @Ddudduu @elaus00 @Junhee8649
+*.gradle.kts                    @thirfir @Ddudduu @elaus00 @Junhee8649
+gradle/                         @thirfir @Ddudduu @elaus00 @Junhee8649
+gradle.properties               @thirfir @Ddudduu @elaus00 @Junhee8649
+settings.gradle*                @thirfir @Ddudduu @elaus00 @Junhee8649
+buildSrc/                       @thirfir @Ddudduu @elaus00 @Junhee8649
+gradle/libs.versions.toml       @thirfir @Ddudduu @elaus00 @Junhee8649
+**/proguard-rules.pro           @thirfir @Ddudduu @elaus00 @Junhee8649
 
 # 매니페스트 / 런타임 설정
-**/AndroidManifest.xml          @depromeet/18th_team6_android
+**/AndroidManifest.xml          @thirfir @Ddudduu @elaus00 @Junhee8649
 
 # CI / GitHub 설정
-.github/workflows/              @depromeet/18th_team6_android
-.github/CODEOWNERS              @depromeet/18th_team6_android
+.github/workflows/              @thirfir @Ddudduu @elaus00 @Junhee8649
+.github/CODEOWNERS              @thirfir @Ddudduu @elaus00 @Junhee8649
 
 # 코드 품질 설정
-.editorconfig                   @depromeet/18th_team6_android
-**/detekt.yml                   @depromeet/18th_team6_android
+.editorconfig                   @thirfir @Ddudduu @elaus00 @Junhee8649
+**/detekt.yml                   @thirfir @Ddudduu @elaus00 @Junhee8649


### PR DESCRIPTION
### 작업 요약

- `.github/CODEOWNERS` 추가
- 중대 변경(gradle/manifest/workflows 등) 시 코드오너 승인 자동 요구

### 관련 이슈

- Closes #4
- Epic: #1
- 후속 human-task: #5

### 변경 사항

- `.github/CODEOWNERS` 신규 생성
- 기본 owner: `@depromeet/18th_team6_android`
- 중대 경로: `*.gradle*`, `gradle/`, `AndroidManifest.xml`, `.github/workflows/`, `proguard-rules.pro`, `detekt.yml`, `.editorconfig`

### 변경 이유

- 중대 변경 시 2인 승인을 수동 합의가 아닌 시스템으로 강제하기 위함
- 브랜치 보호의 "Require review from Code Owners"와 결합 시 일반 1인 + 코드오너 1인 = 자동 2인

### 영향 범위

- [x] 일반 기능 변경
- [ ] UI 변경
- [ ] API 연동 변경
- [ ] 공통 컴포넌트 변경
- [x] 시스템 영향 가능 (리뷰 정책)

### 리뷰 요청 포인트

- 중대 경로 목록이 충분한지 (누락/과다 여부)
- 팀 전체를 기본 owner로 두는 것에 이견 없는지

### 테스트 / 검증

- [ ] build 통과
- [ ] ktlint 통과
- [ ] detekt 통과
- [ ] unit test 통과
- [x] 수동 테스트 완료 (파일 문법/경로 확인)

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#4-codeowners-추가`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식
- [x] self-review 완료
- [x] 문서 반영 필요 시 반영 완료