### PR TITLE
feat: 리뷰어 자동 배정 워크플로우 추가

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,24 @@
+# 리뷰어 자동 배정 설정 (kentaro-m/auto-assign-action)
+# 팀원 리스트에서 PR 작성자를 제외하고 랜덤으로 N명을 리뷰어로 지정한다.
+
+# 리뷰어 자동 요청 활성화
+addReviewers: true
+
+# PR 작성자를 자동으로 assignee로 지정
+addAssignees: author
+
+# 리뷰어 풀 (2026 디프만 18기 Android 6팀)
+reviewers:
+  - thirfir     # 이상일 (파트장)
+  - Ddudduu     # 임지원
+  - elaus00     # 최지우
+  - Junhee8649  # 이준희
+
+# 리뷰어 풀에서 랜덤으로 선택할 인원 수
+# 팀원 4명 중 작성자 제외 3명에서 2명을 뽑는다
+numberOfReviewers: 2
+
+# 이 키워드가 PR 제목에 포함되면 자동 배정을 건너뛴다
+skipKeywords:
+  - wip
+  - WIP

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,17 @@
+name: Auto Assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviewers:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Auto assign reviewers and author as assignee
+        uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: .github/auto_assign.yml


### PR DESCRIPTION
### 작업 요약

- GitHub Actions 기반 리뷰어 자동 배정 워크플로우 추가
- PR open / ready_for_review 시 팀원 4명 중 2명 랜덤 배정

### 관련 이슈

- Closes #7
- Epic: #1

### 변경 사항

- `.github/workflows/auto-assign.yml` 신규 생성
- `.github/auto_assign.yml` 신규 생성 (설정)
- 사용 Action: `kentaro-m/auto-assign-action@v2.0.0`

### 변경 이유

- Free 플랜 private 레포에서 branch protection, ruleset, Team Code Review Assignment가 전부 막힘
- CODEOWNERS는 전원 요청이라 부하 분산이 안 됨
- Actions로 "작성자 제외 + 랜덤 2명 배정"을 무료로 구현

### 영향 범위

- [x] 일반 기능 변경
- [ ] UI 변경
- [ ] API 연동 변경
- [ ] 공통 컴포넌트 변경
- [x] 시스템 영향 가능 (리뷰 프로세스)

### 리뷰 요청 포인트

- 리뷰어 수 `2`가 적절한지 (4명 팀이라면 2명 추천)
- `skipKeywords`에 `wip/WIP` 외 추가할 키워드가 있는지
- `addAssignees: author` (PR 작성자 = assignee) 정책이 맞는지

### 테스트 / 검증

- [ ] build 통과
- [ ] ktlint 통과
- [ ] detekt 통과
- [ ] unit test 통과
- [ ] 수동 테스트 완료 (머지 후 다음 PR에서 자동 배정 확인 필요)

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#7-리뷰어-자동-배정`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식
- [x] self-review 완료
- [x] 문서 반영 필요 시 반영 완료