### PR TITLE
feat: main/develop 보호 ruleset JSON 추가

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,31 @@
+# GitHub Rulesets
+
+이 디렉토리에는 GitHub Ruleset JSON 파일을 보관합니다. GitHub UI에서 import하여 적용합니다.
+
+## 적용 방법
+
+1. https://github.com/depromeet/18th-team6-Android/settings/rules 접속
+2. **New ruleset** → **Import a ruleset** 클릭
+3. 이 디렉토리의 JSON 파일 업로드
+4. 내용 확인 후 **Create** 클릭
+
+## 파일 목록
+
+### `protect-main-develop.json`
+
+`main`, `develop` 브랜치 보호 규칙.
+
+- **deletion 차단**: 브랜치 삭제 불가
+- **non_fast_forward 차단**: force push 불가
+- **pull_request 필수**:
+  - 승인 1명 필요
+  - 새 커밋 푸시 시 기존 승인 무효화 (dismiss_stale_reviews_on_push)
+  - 모든 대화 resolved 상태여야 머지 가능 (required_review_thread_resolution)
+  - 허용 머지 방식: merge / squash / rebase
+
+> **주의**: Ruleset은 Free 플랜 private 레포에서는 적용되지 않을 수 있습니다. 403 에러가 나면 레포를 public으로 전환하거나 GitHub Team 이상 플랜으로 업그레이드가 필요합니다.
+
+## 참고
+
+- [GitHub Docs - Creating rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
+- [GitHub Docs - Available rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)

--- a/.github/rulesets/protect-main-develop.json
+++ b/.github/rulesets/protect-main-develop.json
@@ -1,0 +1,34 @@
+{
+  "name": "Protect main and develop",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main",
+        "refs/heads/develop"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### 작업 요약

- `main`, `develop` 보호용 Ruleset JSON 파일 추가
- GitHub UI에서 import하여 적용 가능

### 관련 이슈

- Closes #9
- Epic: #1

### 변경 사항

- `.github/rulesets/protect-main-develop.json` 신규 생성
- `.github/rulesets/README.md` 신규 생성 (import 방법 안내)

### 변경 이유

- Ruleset API가 Free 플랜 private에서 막혀 있어 JSON 파일로 보관 후 관리자 UI import 방식 채택
- 팀 내 Ruleset 설정을 코드로 버전 관리하여 재현 가능성 확보
- CODEOWNERS 정책은 폐기(#4 close)하고 이 ruleset + Actions 자동 배정(#7)으로 대체

### 규칙 요약

| 규칙 | 설정 |
|---|---|
| 타겟 브랜치 | `main`, `develop` |
| 브랜치 삭제 | 차단 |
| Force push | 차단 |
| PR 필수 | 예 |
| 승인 필요 인원 | **1명** (팀 합의로 변경 가능) |
| 새 커밋 시 기존 승인 | 무효화 |
| 대화 resolved 필수 | 예 |
| 허용 머지 방식 | merge / squash / rebase |

### 영향 범위

- [x] 일반 기능 변경
- [ ] UI 변경
- [ ] API 연동 변경
- [ ] 공통 컴포넌트 변경
- [x] 시스템 영향 가능 (브랜치 보호 정책)

### 리뷰 요청 포인트

- `required_approving_review_count: 1` 이 적절한지 (2로 올릴지)
- 머지 방식(merge/squash/rebase 전부 허용) 정책이 맞는지

### 테스트 / 검증

- [x] JSON 문법 유효 (`jq` 검증 통과)
- [ ] 관리자가 UI에서 import 시도 → 성공 또는 플랜 제약 확인 필요
- [ ] build / ktlint / detekt / unit test — 해당 없음

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#9-ruleset-json`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식
- [x] self-review 완료
- [x] 문서 반영 필요 시 반영 완료 (rulesets/README.md)