### PR TITLE
chore: lint 검사 체계 정리

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
 *.kt text eol=lf
 *.kts text eol=lf
 *.toml text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
 .editorconfig text eol=lf
+.gitattributes text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,6 @@
 *.xml text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+hooks/* text eol=lf
 .editorconfig text eol=lf
 .gitattributes text eol=lf

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,0 +1,39 @@
+name: Detekt
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: detekt-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detekt:
+    name: detekt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Run detekt
+        run: ./gradlew detekt

--- a/android/app/detekt-baseline.xml
+++ b/android/app/detekt-baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
+</SmellBaseline>

--- a/android/app/src/main/kotlin/com/obrit/obrit/App.kt
+++ b/android/app/src/main/kotlin/com/obrit/obrit/App.kt
@@ -18,11 +18,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-@Preview
-fun App() {
+internal fun App() {
     MaterialTheme {
         var showContent by remember { mutableStateOf(false) }
         Column(

--- a/android/app/src/main/kotlin/com/obrit/obrit/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/obrit/obrit/MainActivity.kt
@@ -20,6 +20,6 @@ class MainActivity : ComponentActivity() {
 
 @Preview
 @Composable
-fun AppAndroidPreview() {
+private fun AppAndroidPreview() {
     App()
 }

--- a/android/core/ui/detekt-baseline.xml
+++ b/android/core/ui/detekt-baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
+</SmellBaseline>

--- a/android/core/ui/src/main/java/com/obrit/android/core/ui/extensions/ViewModelExtensions.kt
+++ b/android/core/ui/src/main/java/com/obrit/android/core/ui/extensions/ViewModelExtensions.kt
@@ -1,9 +1,12 @@
 package com.obrit.android.core.ui.extensions
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import com.obrit.android.core.ui.BaseContainerHost
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 
-fun <T> ViewModel.vmAsync(block: suspend CoroutineScope.() -> T): Deferred<T> = viewModelScope.async(block = block)
+suspend fun <T> BaseContainerHost<*, *>.vmAsync(block: suspend CoroutineScope.() -> T): Deferred<T> =
+    coroutineScope {
+        async(block = block)
+    }

--- a/android/feature/agent/detekt-baseline.xml
+++ b/android/feature/agent/detekt-baseline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>UnusedParameter:AgentScreenFailureContent.kt$modifier: Modifier = Modifier</ID>
+    <ID>UnusedParameter:AgentScreenLoadingContent.kt$modifier: Modifier = Modifier</ID>
+    <ID>UnusedParameter:AgentScreenSuccessContent.kt$modifier: Modifier = Modifier</ID>
+    <ID>UnusedParameter:AgentScreenSuccessContent.kt$state: AgentUiState.Success</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/android/feature/agent/src/main/java/com/obrit/feature/agent/viewmodel/AgentViewModel.kt
+++ b/android/feature/agent/src/main/java/com/obrit/feature/agent/viewmodel/AgentViewModel.kt
@@ -1,7 +1,6 @@
 package com.obrit.feature.agent.viewmodel
 
 import androidx.compose.runtime.Immutable
-import androidx.lifecycle.viewModelScope
 import com.obrit.android.core.ui.BaseContainerHost
 import com.obrit.android.core.ui.extensions.vmAsync
 import com.obrit.obrit.shared.data.repository.AgentRepository
@@ -10,7 +9,6 @@ import com.obrit.obrit.shared.model.agents.Agent
 import com.obrit.obrit.shared.model.agents.AgentType
 import com.obrit.obrit.shared.model.agents.PatchAgentParams
 import com.obrit.obrit.shared.model.sessions.Session
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.viewmodel.container
 
 class AgentViewModel internal constructor(
@@ -51,32 +49,28 @@ class AgentViewModel internal constructor(
         description: String,
         type: AgentType,
     ) = intent {
-        viewModelScope.launch {
-            agentRepository
-                .createAgent(name, description, type)
-                .onSuccess {
-                    reduceOn<AgentUiState.Success> {
-                        state.copy(
-                            agents = state.agents + it,
-                        )
-                    }
-                }.onFailure { e ->
-                    postSideEffect(AgentSideEffect.OnError(e))
+        agentRepository
+            .createAgent(name, description, type)
+            .onSuccess {
+                reduceOn<AgentUiState.Success> {
+                    state.copy(
+                        agents = state.agents + it,
+                    )
                 }
-        }
+            }.onFailure { e ->
+                postSideEffect(AgentSideEffect.OnError(e))
+            }
     }
 
     fun deleteAgent(id: Int) =
         intent {
-            viewModelScope.launch {
-                agentRepository
-                    .deleteAgent(id)
-                    .onSuccess {
-                        // 성공에 대한 동작
-                    }.onFailure { e ->
-                        postSideEffect(AgentSideEffect.OnError(e))
-                    }
-            }
+            agentRepository
+                .deleteAgent(id)
+                .onSuccess {
+                    // 성공에 대한 동작
+                }.onFailure { e ->
+                    postSideEffect(AgentSideEffect.OnError(e))
+                }
         }
 
     fun patchAgent(
@@ -85,32 +79,30 @@ class AgentViewModel internal constructor(
         description: String,
         type: AgentType,
     ) = intent {
-        viewModelScope.launch {
-            agentRepository
-                .patchAgent(
-                    PatchAgentParams(
-                        id = id,
-                        name = name,
-                        description = description,
-                        type = type,
-                    ),
-                ).onSuccess { patchedAgent ->
-                    reduceOn<AgentUiState.Success> {
-                        state.copy(
-                            agents =
-                                state.agents.map { agent ->
-                                    if (agent.id == patchedAgent.id) {
-                                        patchedAgent
-                                    } else {
-                                        agent
-                                    }
-                                },
-                        )
-                    }
-                }.onFailure { e ->
-                    postSideEffect(AgentSideEffect.OnError(e))
+        agentRepository
+            .patchAgent(
+                PatchAgentParams(
+                    id = id,
+                    name = name,
+                    description = description,
+                    type = type,
+                ),
+            ).onSuccess { patchedAgent ->
+                reduceOn<AgentUiState.Success> {
+                    state.copy(
+                        agents =
+                            state.agents.map { agent ->
+                                if (agent.id == patchedAgent.id) {
+                                    patchedAgent
+                                } else {
+                                    agent
+                                }
+                            },
+                    )
                 }
-        }
+            }.onFailure { e ->
+                postSideEffect(AgentSideEffect.OnError(e))
+            }
     }
 
     fun onAgentClick(agent: Agent) =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,10 @@ plugins {
     alias(libs.plugins.ktlint)
 }
 
+dependencies {
+    ktlintRuleset(libs.compose.rules.ktlint)
+}
+
 fun Project.configureDetekt() {
     extensions.configure<DetektExtension>("detekt") {
         baseline = file("detekt-baseline.xml")
@@ -34,6 +38,10 @@ configureDetekt()
 subprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    dependencies {
+        add("ktlintRuleset", rootProject.libs.compose.rules.ktlint)
+    }
 
     configureDetekt()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,39 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.Project
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.composeCompiler) apply false
+    alias(libs.plugins.detekt)
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ktlint)
 }
 
+fun Project.configureDetekt() {
+    extensions.configure<DetektExtension>("detekt") {
+        baseline = file("detekt-baseline.xml")
+        buildUponDefaultConfig = true
+        config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+        source.setFrom(files("src"))
+    }
+
+    tasks.withType<Detekt>().configureEach {
+        include("**/*.kt", "**/*.kts")
+        exclude("**/build/**")
+    }
+}
+
+configureDetekt()
+
 subprojects {
+    apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    configureDetekt()
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -7,3 +7,6 @@ naming:
 style:
   MaxLineLength:
     active: false
+  UnusedPrivateMember:
+    ignoreAnnotated:
+      - Preview

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,9 @@
+naming:
+  FunctionNaming:
+    active: false
+  MatchingDeclarationName:
+    active: false
+
+style:
+  MaxLineLength:
+    active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-core = "1.18.0"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.10.0"
 androidx-testExt = "1.3.0"
+detekt = "1.23.8"
 junit = "4.13.2"
 kotlin = "2.3.20"
 kotlinxSerializationJson = "1.11.0"
@@ -67,6 +68,7 @@ orbit-compose = { module = "org.orbit-mvi:orbit-compose", version.ref = "orbit" 
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.10.0"
 androidx-testExt = "1.3.0"
 detekt = "1.23.8"
+composeRules = "0.4.23"
 junit = "4.13.2"
 kotlin = "2.3.20"
 kotlinxSerializationJson = "1.11.0"
@@ -39,6 +40,7 @@ androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+compose-rules-ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "composeRules" }
 
 # region Serialization
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,4 +6,4 @@ Install the versioned hooks once per clone:
 git config core.hooksPath hooks
 ```
 
-The `pre-commit` hook runs `ktlintCheck` and blocks the commit when ktlint fails.
+The `pre-commit` hook runs `ktlintCheck` and `detekt`, and blocks the commit when either check fails.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -28,3 +28,14 @@ if ! "$GRADLE_SHELL" ./gradlew ktlintCheck; then
 fi
 
 echo "pre-commit: ktlintCheck passed."
+
+echo "pre-commit: running detekt..."
+
+if ! "$GRADLE_SHELL" ./gradlew detekt; then
+  echo
+  echo "pre-commit: detekt failed. Commit aborted."
+  echo "pre-commit: fix reported issues and try again."
+  exit 1
+fi
+
+echo "pre-commit: detekt passed."

--- a/shared/detekt-baseline.xml
+++ b/shared/detekt-baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
+</SmellBaseline>

--- a/shared/model/detekt-baseline.xml
+++ b/shared/model/detekt-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MagicNumber:CreateAgentError.kt$CreateAgentError.DuplicatedName$10001</ID>
+    <ID>MagicNumber:CreateAgentError.kt$CreateAgentError.EmptyName$10000</ID>
+    <ID>MagicNumber:CreateAgentError.kt$CreateAgentError.InvalidAgentType$10003</ID>
+    <ID>MagicNumber:CreateAgentError.kt$CreateAgentError.InvalidNameFormat$10002</ID>
+    <ID>MagicNumber:DeleteAgentError.kt$DeleteAgentError.InvalidId$20000</ID>
+    <ID>MagicNumber:PatchAgentError.kt$PatchAgentError.DuplicatedName$10001</ID>
+    <ID>MagicNumber:PatchAgentError.kt$PatchAgentError.EmptyName$10000</ID>
+    <ID>MagicNumber:PatchAgentError.kt$PatchAgentError.InvalidAgentType$10003</ID>
+    <ID>MagicNumber:PatchAgentError.kt$PatchAgentError.InvalidNameFormat$10002</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shared/network/detekt-baseline.xml
+++ b/shared/network/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MagicNumber:RemoteError.kt$400</ID>
+    <ID>MagicNumber:RemoteError.kt$401</ID>
+    <ID>MagicNumber:RemoteError.kt$403</ID>
+    <ID>MagicNumber:RemoteError.kt$404</ID>
+    <ID>MagicNumber:RemoteError.kt$500</ID>
+    <ID>MagicNumber:RemoteError.kt$600</ID>
+    <ID>TooGenericExceptionCaught:ErrorUtils.kt$exception: Throwable</ID>
+  </CurrentIssues>
+</SmellBaseline>


### PR DESCRIPTION
﻿### 작업 요약

- ktlint, Compose ktlint rules, detekt 기반의 lint/정적 분석 검사 체계를 정리했습니다.
- detekt CI와 pre-commit hook에 detekt 검사를 추가했습니다.
- Compose lint 적용으로 감지된 Preview visibility 및 detekt Preview 예외 설정을 반영했습니다.
- 커스텀 detekt 전용 룰은 이번 PR에 포함하지 않았으며, 추후 별도 작업으로 추가 예정입니다.

### 관련 이슈

- Related to #24

### 변경 사항

- detekt Gradle 플러그인 및 모듈별 baseline 추가
- `.github/workflows/detekt.yml` 추가로 PR에서 detekt 검사 실행
- `io.nlopez.compose.rules:ktlint:0.4.23` 추가 및 ktlint ruleset 연결
- `config/detekt/detekt.yml` 추가
  - ktlint/Compose와 겹치는 `FunctionNaming`, `MatchingDeclarationName`, `MaxLineLength` 비활성화
  - `@Preview` 함수에 대한 `UnusedPrivateMember` 예외 추가
- pre-commit hook에서 `ktlintCheck` 이후 `detekt`도 실행하도록 변경
- shell hook LF 유지를 위해 `.gitattributes`에 `hooks/* text eol=lf` 추가
- Compose Preview 전용 함수 visibility 정리
- ViewModel coroutine scope 예시 코드 정리

### 변경 이유

- 포맷은 ktlint가 담당하고, 품질 검사는 detekt가 담당하도록 역할을 분리하기 위해 변경했습니다.
- Compose 전용 컨벤션을 ktlint ruleset으로 검사해 일반 ktlint와 Compose 규칙 사이의 책임을 명확히 했습니다.
- 로컬 commit 전과 GitHub PR 단계에서 동일한 lint 품질 기준을 적용하기 위해 pre-commit과 CI를 보강했습니다.
- 커스텀 detekt 전용 룰은 아직 포함하지 않았으며, 기본 detekt 설정 안정화 이후 추후 추가할 예정입니다.

### 영향 범위

- [ ] 일반 기능 변경
- [ ] UI 변경
- [ ] API 연동 변경
- [ ] 공통 컴포넌트 변경
- [x] 시스템 영향 가능 (`lint`, `gradle`, `manifest`, build config 등)

> 시스템 영향 변경이 포함된 경우 리뷰어 2인 승인 기준을 적용할 수 있습니다.

### 리뷰 요청 포인트

- ktlint, Compose rules, detekt 간 역할 분리가 적절한지 확인 부탁드립니다.
- detekt baseline 및 `@Preview` 예외 설정 범위가 과하지 않은지 확인 부탁드립니다.
- 커스텀 detekt 전용 룰은 추후 별도 PR에서 추가 예정입니다.

### 테스트 / 검증

- [ ] build 통과
- [x] ktlint 통과
- [x] detekt 통과
- [ ] unit test 통과
- [x] 수동 테스트 완료

### 스크린샷 / 영상

UI 변경이 있는 경우 첨부해주세요.

| 변경 전 | 변경 후 |
| --- | --- |
|  |  |

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#이슈번호-기능명`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식 (`feat: ...`, `fix: ...`, `refactor: ...`)
- [x] self-review 완료
- [x] 문서 반영 필요 시 반영 완료
