### PR TITLE
feat: Common Black 00-80 Dim token 반영

### DIFF
--- a/android/core/designsystem/src/main/java/com/obrit/android/core/designsystem/theme/Color.kt
+++ b/android/core/designsystem/src/main/java/com/obrit/android/core/designsystem/theme/Color.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import com.obrit.obrit.shared.designsystem.tokens.atom.color.AtomColors
+import com.obrit.obrit.shared.designsystem.tokens.semantic.SemanticColors
 
 val LocalOBRitColor =
     staticCompositionLocalOf {
@@ -14,6 +15,7 @@ val LocalOBRitColor =
 data class OBRitColor(
     val common00: Color = Color(AtomColors.Common.S00),
     val common100: Color = Color(AtomColors.Common.S100),
+    val backgroundDefaultDimDefault: Color = Color(SemanticColors.Background.Default.DimDefault),
     val gray50: Color = Color(AtomColors.Gray.S50),
     val gray100: Color = Color(AtomColors.Gray.S100),
     val gray150: Color = Color(AtomColors.Gray.S150),

--- a/shared/design-system/src/commonMain/kotlin/com/obrit/obrit/shared/designsystem/tokens/semantic/SemanticColors.kt
+++ b/shared/design-system/src/commonMain/kotlin/com/obrit/obrit/shared/designsystem/tokens/semantic/SemanticColors.kt
@@ -18,7 +18,7 @@ object SemanticColors {
             const val MiddleGrayDefault: Long = AtomColors.Gray.S450
             const val MiddleGraySecondary: Long = AtomColors.Gray.S600
             const val MiddleGrayTertiary: Long = AtomColors.Gray.S700
-            const val DimDefault: Long = AtomColors.GrayOpacity.S900
+            const val DimDefault: Long = AtomColors.CommonOpacity.CommonBlack.S00_80
             const val DimSecondary: Long = AtomColors.GrayOpacity.S800
             const val DimTertiary: Long = AtomColors.GrayOpacity.S700
         }


### PR DESCRIPTION
## Summary
- `SemanticColors.Background.Default.DimDefault`가 `Common Opacity/Common Black/00-80`을 참조하도록 변경했습니다.
- Android theme adapter에서는 atom 이름 대신 `backgroundDefaultDimDefault`로 semantic Dim Default 색상을 노출했습니다.
- Atom `CommonBlack.S00_80` 값은 tracked token export 기준 `#000000` alpha 0.8과 일치해 그대로 유지했습니다.

## Validation
- `bash ./gradlew :shared:design-system:compileKotlinMetadata :android:core:designsystem:compileDebugKotlin`
- `bash ./gradlew ktlintCheck`
- `grep -r "androidx\." shared/design-system/src/commonMain/ || true`

Closes #36