### PR TITLE
feat: Figma 디자인 컴포넌트 iOS 구현

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,28 +1,8 @@
 import SwiftUI
-import Shared
 
 struct ContentView: View {
-    @State private var showContent = false
     var body: some View {
-        VStack {
-            Button("Click me!") {
-                withAnimation {
-                    showContent = !showContent
-                }
-            }
-
-            if showContent {
-                VStack(spacing: 16) {
-                    Image(systemName: "swift")
-                        .font(.system(size: 200))
-                        .foregroundColor(.accentColor)
-                    Text("SwiftUI: \(Greeting().greet())")
-                }
-                .transition(.move(edge: .top).combined(with: .opacity))
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .padding()
+        DesignSystemPreviewGallery()
     }
 }
 

--- a/iosApp/iosApp/DesignSystem/Components/OBRitBadge.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitBadge.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import Shared
 
-// 배지 타입이 Figma 레이어 이름을 그대로 가져와서 직관적이지 못함. 보다 의미론적으로 추가될 필요 있을듯함
 public enum OBRitBadgeType {
     case warningFilled
     case gray750Filled
@@ -35,7 +34,7 @@ public struct OBRitBadge: View {
     private var containerColor: Color {
         switch type {
         case .warningFilled:
-            return OBRitColors.red300
+            return OBRitColors.backgroundWarningDefault
         case .gray750Filled:
             return OBRitColors.gray750
         case .warningWhiteBackgroundFilled:
@@ -47,13 +46,12 @@ public struct OBRitBadge: View {
         }
     }
 
-    // Semantic 색상과 Atom 색상의 혼용은 의도된 부분?
     private var contentColor: Color {
         switch type {
         case .warningFilled, .gray750Filled, .red250Filled:
             return OBRitColors.common00
         case .warningWhiteBackgroundFilled, .red800Filled:
-            return OBRitColors.red300
+            return OBRitColors.textWarningDefault
         }
     }
 }

--- a/iosApp/iosApp/DesignSystem/Components/OBRitBadge.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitBadge.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import Shared
+
+// 배지 타입이 Figma 레이어 이름을 그대로 가져와서 직관적이지 못함. 보다 의미론적으로 추가될 필요 있을듯함
+public enum OBRitBadgeType {
+    case warningFilled
+    case gray750Filled
+    case warningWhiteBackgroundFilled
+    case red250Filled
+    case red800Filled
+}
+
+public struct OBRitBadge: View {
+    private let text: String
+    private let type: OBRitBadgeType
+
+    public init(
+        text: String,
+        type: OBRitBadgeType = .warningFilled
+    ) {
+        self.text = text
+        self.type = type
+    }
+
+    public var body: some View {
+        Text(text)
+            .lineLimit(1)
+            .obritTextStyle(OBRitTypography.xs, weight: AtomFontWeight.shared.Bold, color: contentColor)
+            .padding(.horizontal, OBRitSpacing.s2)
+            .padding(.vertical, OBRitSpacing.s1)
+            .background(containerColor)
+            .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.small))
+    }
+
+    private var containerColor: Color {
+        switch type {
+        case .warningFilled:
+            return OBRitColors.red300
+        case .gray750Filled:
+            return OBRitColors.gray750
+        case .warningWhiteBackgroundFilled:
+            return OBRitColors.common00
+        case .red250Filled:
+            return OBRitColors.red250
+        case .red800Filled:
+            return OBRitColors.red800
+        }
+    }
+
+    // Semantic 색상과 Atom 색상의 혼용은 의도된 부분?
+    private var contentColor: Color {
+        switch type {
+        case .warningFilled, .gray750Filled, .red250Filled:
+            return OBRitColors.common00
+        case .warningWhiteBackgroundFilled, .red800Filled:
+            return OBRitColors.red300
+        }
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitBottomSheet.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitBottomSheet.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+public struct OBRitBottomSheet<Content: View>: View {
+    private let contentHeight: CGFloat
+    private let content: Content
+
+    public init(
+        contentHeight: CGFloat = 414,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.contentHeight = contentHeight
+        self.content = content()
+    }
+
+    public var body: some View {
+        VStack(spacing: OBRitSpacing.s2_5) {
+            OBRitBottomSheetHeader()
+
+            content
+                .frame(
+                    width: OBRitBottomSheetMetrics.contentWidth,
+                    height: contentHeight,
+                    alignment: .top
+                )
+        }
+        .frame(width: OBRitBottomSheetMetrics.sheetWidth)
+        .padding(.bottom, OBRitSpacing.s5)
+        .background(OBRitColors.gray900)
+        .clipShape(OBRitTopRoundedRectangle(radius: OBRitRadius.bottomSheet))
+    }
+}
+
+private struct OBRitBottomSheetHeader: View {
+    var body: some View {
+        HStack {
+            Capsule()
+                .fill(OBRitColors.gray250.opacity(0.4))
+                .frame(
+                    width: OBRitBottomSheetMetrics.handleWidth,
+                    height: OBRitBottomSheetMetrics.handleHeight
+                )
+        }
+        .frame(width: OBRitBottomSheetMetrics.sheetWidth)
+        .padding(OBRitSpacing.s4)
+    }
+}
+
+private struct OBRitTopRoundedRectangle: Shape {
+    let radius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        let cornerRadius = min(radius, rect.width / 2, rect.height / 2)
+
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + cornerRadius))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + cornerRadius, y: rect.minY),
+            control: CGPoint(x: rect.minX, y: rect.minY)
+        )
+        path.addLine(to: CGPoint(x: rect.maxX - cornerRadius, y: rect.minY))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY + cornerRadius),
+            control: CGPoint(x: rect.maxX, y: rect.minY)
+        )
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+private enum OBRitBottomSheetMetrics {
+    static let sheetWidth: CGFloat = 412
+    static let contentWidth: CGFloat = 372
+    static let contentHeight: CGFloat = 414
+    static let handleWidth: CGFloat = 32
+    static let handleHeight: CGFloat = 4
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitButton.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitButton.swift
@@ -39,7 +39,7 @@ public struct OBRitFilledButton<Content: View>: View {
 
     public var body: some View {
         Button(action: action) {
-            HStack(spacing: OBRitSpacing.s2) {
+            HStack(spacing: OBRitSpacing.s0_5) {
                 content(contentColor)
             }
             .frame(minHeight: height)
@@ -73,7 +73,7 @@ public struct OBRitFilledButton<Content: View>: View {
         case .large:
             return OBRitSpacing.s6
         case .middle:
-            return 22
+            return OBRitSpacing.s5
         case .small:
             return 14
         }
@@ -113,15 +113,69 @@ public struct OBRitFilledButton<Content: View>: View {
     }
 }
 
-public struct OBRitFilledTextButton: View {
+public struct OBRitFilledTextButton<LeadingIcon: View, TrailingIcon: View>: View {
     private let text: String
     private let size: OBRitFilledButtonSize
     private let color: OBRitFilledButtonColor
     private let enabled: Bool
     private let fillsWidth: Bool
     private let action: () -> Void
+    private let hasLeadingIcon: Bool
+    private let hasTrailingIcon: Bool
+    private let leadingIcon: (Color) -> LeadingIcon
+    private let trailingIcon: (Color) -> TrailingIcon
 
     public init(
+        text: String,
+        size: OBRitFilledButtonSize = .large,
+        color: OBRitFilledButtonColor = .green,
+        enabled: Bool = true,
+        fillsWidth: Bool = false,
+        action: @escaping () -> Void,
+        @ViewBuilder leadingIcon: @escaping (Color) -> LeadingIcon,
+        @ViewBuilder trailingIcon: @escaping (Color) -> TrailingIcon
+    ) {
+        self.text = text
+        self.size = size
+        self.color = color
+        self.enabled = enabled
+        self.fillsWidth = fillsWidth
+        self.action = action
+        self.hasLeadingIcon = true
+        self.hasTrailingIcon = true
+        self.leadingIcon = leadingIcon
+        self.trailingIcon = trailingIcon
+    }
+
+    public var body: some View {
+        OBRitFilledButton(
+            size: size,
+            color: color,
+            enabled: enabled,
+            fillsWidth: fillsWidth,
+            action: action
+        ) { contentColor in
+            if hasLeadingIcon {
+                leadingIcon(contentColor)
+                    .frame(width: OBRitFilledButtonIconSize, height: OBRitFilledButtonIconSize)
+            }
+            Text(text)
+                .lineLimit(1)
+                .obritTextStyle(
+                    size == .small ? OBRitTypography.base : OBRitTypography.xl,
+                    weight: AtomFontWeight.shared.SemiBold,
+                    color: contentColor
+                )
+            if hasTrailingIcon {
+                trailingIcon(contentColor)
+                    .frame(width: OBRitFilledButtonIconSize, height: OBRitFilledButtonIconSize)
+            }
+        }
+    }
+}
+
+public extension OBRitFilledTextButton where LeadingIcon == EmptyView, TrailingIcon == EmptyView {
+    init(
         text: String,
         size: OBRitFilledButtonSize = .large,
         color: OBRitFilledButtonColor = .green,
@@ -135,23 +189,57 @@ public struct OBRitFilledTextButton: View {
         self.enabled = enabled
         self.fillsWidth = fillsWidth
         self.action = action
-    }
-
-    public var body: some View {
-        OBRitFilledButton(
-            size: size,
-            color: color,
-            enabled: enabled,
-            fillsWidth: fillsWidth,
-            action: action
-        ) { contentColor in
-            Text(text)
-                .lineLimit(1)
-                .obritTextStyle(
-                    size == .small ? OBRitTypography.base : OBRitTypography.xl,
-                    weight: AtomFontWeight.shared.Bold,
-                    color: contentColor
-                )
-        }
+        self.hasLeadingIcon = false
+        self.hasTrailingIcon = false
+        self.leadingIcon = { _ in EmptyView() }
+        self.trailingIcon = { _ in EmptyView() }
     }
 }
+
+public extension OBRitFilledTextButton where TrailingIcon == EmptyView {
+    init(
+        text: String,
+        size: OBRitFilledButtonSize = .large,
+        color: OBRitFilledButtonColor = .green,
+        enabled: Bool = true,
+        fillsWidth: Bool = false,
+        action: @escaping () -> Void,
+        @ViewBuilder leadingIcon: @escaping (Color) -> LeadingIcon
+    ) {
+        self.text = text
+        self.size = size
+        self.color = color
+        self.enabled = enabled
+        self.fillsWidth = fillsWidth
+        self.action = action
+        self.hasLeadingIcon = true
+        self.hasTrailingIcon = false
+        self.leadingIcon = leadingIcon
+        self.trailingIcon = { _ in EmptyView() }
+    }
+}
+
+public extension OBRitFilledTextButton where LeadingIcon == EmptyView {
+    init(
+        text: String,
+        size: OBRitFilledButtonSize = .large,
+        color: OBRitFilledButtonColor = .green,
+        enabled: Bool = true,
+        fillsWidth: Bool = false,
+        action: @escaping () -> Void,
+        @ViewBuilder trailingIcon: @escaping (Color) -> TrailingIcon
+    ) {
+        self.text = text
+        self.size = size
+        self.color = color
+        self.enabled = enabled
+        self.fillsWidth = fillsWidth
+        self.action = action
+        self.hasLeadingIcon = false
+        self.hasTrailingIcon = true
+        self.leadingIcon = { _ in EmptyView() }
+        self.trailingIcon = trailingIcon
+    }
+}
+
+private let OBRitFilledButtonIconSize: CGFloat = 16

--- a/iosApp/iosApp/DesignSystem/Components/OBRitCard.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitCard.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import Shared
 
+private let obritCardListImageBackgroundColor = Color(red: 48.0 / 255.0, green: 51.0 / 255.0, blue: 62.0 / 255.0)
+
 public enum OBRitCardLevel {
     case l1
     case l2
@@ -143,7 +145,7 @@ public struct OBRitCardList<ImageContent: View>: View {
 
     public var body: some View {
         HStack(spacing: OBRitSpacing.s4) {
-            CardImageBox {
+            CardImageBox(backgroundColor: obritCardListImageBackgroundColor) {
                 image()
             }
             .frame(width: OBRitSpacing.s12, height: OBRitSpacing.s12)
@@ -237,16 +239,21 @@ public extension OBRitCardList where ImageContent == EmptyView {
 }
 
 private struct CardImageBox<Content: View>: View {
+    private let backgroundColor: Color
     private let content: () -> Content
 
-    init(@ViewBuilder content: @escaping () -> Content) {
+    init(
+        backgroundColor: Color = OBRitColors.gray800,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.backgroundColor = backgroundColor
         self.content = content
     }
 
     var body: some View {
         ZStack {
             Circle()
-                .fill(OBRitColors.gray800)
+                .fill(backgroundColor)
             content()
         }
     }

--- a/iosApp/iosApp/DesignSystem/Components/OBRitCard.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitCard.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+import Shared
+
+public enum OBRitCardLevel {
+    case l1
+    case l2
+    case l3
+    case l4
+    case l5
+    case l6
+}
+
+public struct OBRitCardGrid<ImageContent: View>: View {
+    private let level: OBRitCardLevel
+    private let title: String
+    private let stockCount: Int
+    private let daysLabel: String
+    private let image: () -> ImageContent
+
+    public init(
+        level: OBRitCardLevel,
+        title: String,
+        stockCount: Int,
+        daysLabel: String,
+        @ViewBuilder image: @escaping () -> ImageContent
+    ) {
+        self.level = level
+        self.title = title
+        self.stockCount = stockCount
+        self.daysLabel = daysLabel
+        self.image = image
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: OBRitSpacing.s2_5) {
+            CardImageBox {
+                image()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+
+            VStack(alignment: .leading, spacing: OBRitSpacing.s0_5) {
+                Text(title)
+                    .lineLimit(1)
+                    .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+                HStack(spacing: OBRitSpacing.s1) {
+                    Text("\(stockCount)개")
+                        .obritTextStyle(OBRitTypography.xs, weight: AtomFontWeight.shared.Bold, color: gridStockCountColor)
+                    Text("남음")
+                        .obritTextStyle(OBRitTypography.xs, weight: AtomFontWeight.shared.Medium, color: gridStockSuffixColor)
+                }
+            }
+
+            CardBadge(text: daysLabel, containerColor: gridBadgeContainerColor, contentColor: gridBadgeContentColor)
+        }
+        .padding(OBRitSpacing.s4)
+        .frame(width: OBRitSpacing.s40, height: OBRitSpacing.s40)
+        .background(cardContainerColor)
+        .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.extraLarge))
+    }
+
+    private var cardContainerColor: Color {
+        switch level {
+        case .l1:
+            return OBRitColors.red300
+        case .l2, .l3:
+            return OBRitColors.red900
+        case .l4, .l5, .l6:
+            return OBRitColors.gray850
+        }
+    }
+
+    private var gridStockCountColor: Color {
+        switch level {
+        case .l2, .l5:
+            return OBRitColors.red300
+        default:
+            return OBRitColors.common00
+        }
+    }
+
+    private var gridStockSuffixColor: Color {
+        level == .l1 ? OBRitColors.red100 : OBRitColors.gray300
+    }
+
+    private var gridBadgeContainerColor: Color {
+        switch level {
+        case .l1, .l4:
+            return OBRitColors.common00
+        case .l2, .l3:
+            return OBRitColors.red300
+        case .l5, .l6:
+            return OBRitColors.gray750
+        }
+    }
+
+    private var gridBadgeContentColor: Color {
+        switch level {
+        case .l1, .l4:
+            return OBRitColors.red300
+        default:
+            return OBRitColors.common00
+        }
+    }
+}
+
+public extension OBRitCardGrid where ImageContent == EmptyView {
+    init(
+        level: OBRitCardLevel,
+        title: String,
+        stockCount: Int,
+        daysLabel: String
+    ) {
+        self.init(level: level, title: title, stockCount: stockCount, daysLabel: daysLabel) {
+            EmptyView()
+        }
+    }
+}
+
+public struct OBRitCardList<ImageContent: View>: View {
+    private let level: OBRitCardLevel
+    private let title: String
+    private let daysInUseLabel: String
+    private let replaceLabel: String
+    private let sparesLabel: String
+    private let image: () -> ImageContent
+
+    public init(
+        level: OBRitCardLevel,
+        title: String,
+        daysInUseLabel: String,
+        replaceLabel: String,
+        sparesLabel: String,
+        @ViewBuilder image: @escaping () -> ImageContent
+    ) {
+        self.level = level
+        self.title = title
+        self.daysInUseLabel = daysInUseLabel
+        self.replaceLabel = replaceLabel
+        self.sparesLabel = sparesLabel
+        self.image = image
+    }
+
+    public var body: some View {
+        HStack(spacing: OBRitSpacing.s4) {
+            CardImageBox {
+                image()
+            }
+            .frame(width: OBRitSpacing.s12, height: OBRitSpacing.s12)
+
+            VStack(alignment: .leading, spacing: OBRitSpacing.s0_5) {
+                Text(title)
+                    .lineLimit(1)
+                    .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+                HStack(spacing: OBRitSpacing.s0_5) {
+                    Text(daysInUseLabel)
+                        .obritTextStyle(OBRitTypography.s, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+                    Text("째 사용중")
+                        .obritTextStyle(OBRitTypography.s, weight: AtomFontWeight.shared.Medium, color: listInUseSuffixColor)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: OBRitSpacing.s1) {
+                CardBadge(text: replaceLabel, containerColor: listFirstBadgeContainerColor, contentColor: listFirstBadgeContentColor)
+                CardBadge(text: sparesLabel, containerColor: listSecondBadgeContainerColor, contentColor: OBRitColors.common00)
+            }
+        }
+        .padding(.horizontal, OBRitSpacing.s5)
+        .padding(.vertical, OBRitSpacing.s4)
+        .background(cardContainerColor)
+        .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.extraLarge))
+    }
+
+    private var cardContainerColor: Color {
+        switch level {
+        case .l1:
+            return OBRitColors.red300
+        case .l2, .l3:
+            return OBRitColors.red900
+        case .l4, .l5, .l6:
+            return OBRitColors.gray850
+        }
+    }
+
+    private var listInUseSuffixColor: Color {
+        level == .l1 ? OBRitColors.red100 : OBRitColors.gray300
+    }
+
+    private var listFirstBadgeContainerColor: Color {
+        switch level {
+        case .l1:
+            return OBRitColors.red250
+        case .l2:
+            return OBRitColors.common00
+        case .l3, .l4:
+            return OBRitColors.red300
+        case .l5, .l6:
+            return OBRitColors.gray750
+        }
+    }
+
+    private var listFirstBadgeContentColor: Color {
+        level == .l2 ? OBRitColors.red300 : OBRitColors.common00
+    }
+
+    private var listSecondBadgeContainerColor: Color {
+        switch level {
+        case .l1:
+            return OBRitColors.red250
+        case .l2, .l5:
+            return OBRitColors.red300
+        case .l3, .l4, .l6:
+            return OBRitColors.gray750
+        }
+    }
+}
+
+public extension OBRitCardList where ImageContent == EmptyView {
+    init(
+        level: OBRitCardLevel,
+        title: String,
+        daysInUseLabel: String,
+        replaceLabel: String,
+        sparesLabel: String
+    ) {
+        self.init(
+            level: level,
+            title: title,
+            daysInUseLabel: daysInUseLabel,
+            replaceLabel: replaceLabel,
+            sparesLabel: sparesLabel
+        ) {
+            EmptyView()
+        }
+    }
+}
+
+private struct CardImageBox<Content: View>: View {
+    private let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(OBRitColors.gray800)
+            content()
+        }
+    }
+}
+
+private struct CardBadge: View {
+    let text: String
+    let containerColor: Color
+    let contentColor: Color
+
+    var body: some View {
+        Text(text)
+            .lineLimit(1)
+            .obritTextStyle(OBRitTypography.xs, weight: AtomFontWeight.shared.Bold, color: contentColor)
+            .padding(.horizontal, OBRitSpacing.s2)
+            .padding(.vertical, OBRitSpacing.s1)
+            .background(containerColor)
+            .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.small))
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitChip.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitChip.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import Shared
+
+public struct OBRitChip: View {
+    private let text: String
+    private let selected: Bool
+    private let number: Int?
+    private let onClick: () -> Void
+
+    public init(
+        text: String,
+        selected: Bool = false,
+        number: Int? = nil,
+        onClick: @escaping () -> Void
+    ) {
+        self.text = text
+        self.selected = selected
+        self.number = number
+        self.onClick = onClick
+    }
+
+    public var body: some View {
+        Button(action: onClick) {
+            HStack(spacing: OBRitSpacing.s2) {
+                Text(text)
+                if let number {
+                    Text("\(number)")
+                }
+            }
+            .lineLimit(1)
+            .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.Bold, color: contentColor)
+            .padding(.horizontal, OBRitSpacing.s4)
+            .padding(.vertical, OBRitSpacing.s2)
+            .background(containerColor)
+            .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.extraLarge))
+            .contentShape(RoundedRectangle(cornerRadius: OBRitRadius.extraLarge))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var containerColor: Color {
+        selected ? OBRitColors.common00 : OBRitColors.gray800
+    }
+
+    private var contentColor: Color {
+        selected ? OBRitColors.common100 : OBRitColors.common00
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitDropdown.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitDropdown.swift
@@ -6,6 +6,11 @@ public enum OBRitDropdownInputState {
     case error
 }
 
+public enum OBRitDropdownMenuItemSize {
+    case small
+    case large
+}
+
 public struct OBRitDropdown: View {
     private let value: String
     private let placeholder: String
@@ -37,7 +42,7 @@ public struct OBRitDropdown: View {
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: OBRitSpacing.s3) {
+        VStack(alignment: .leading, spacing: OBRitSpacing.s2) {
             Button(action: onClick) {
                 HStack(spacing: OBRitSpacing.s2) {
                     Text(displayedText)
@@ -46,11 +51,11 @@ public struct OBRitDropdown: View {
                         .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: displayedTextColor)
 
                     OBRitIcon(kind: .chevronDown, color: OBRitColors.common00)
-                        .frame(width: OBRitSpacing.s4, height: OBRitSpacing.s4)
+                        .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
                 }
                 .frame(minHeight: OBRitSpacing.s14)
                 .padding(.leading, OBRitSpacing.s5)
-                .padding(.trailing, OBRitSpacing.s6)
+                .padding(.trailing, OBRitSpacing.s5)
                 .padding(.vertical, OBRitSpacing.s4)
                 .background(containerColor)
                 .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.middle))
@@ -87,6 +92,9 @@ public struct OBRitDropdown: View {
     }
 
     private var borderColor: Color? {
+        if !enabled {
+            return OBRitColors.gray700
+        }
         if inputState == .error {
             return OBRitColors.red300
         }
@@ -97,20 +105,107 @@ public struct OBRitDropdown: View {
     }
 }
 
+public struct OBRitDropdownMenuItem: View {
+    private let text: String
+    private let size: OBRitDropdownMenuItemSize
+    private let selected: Bool
+    private let enabled: Bool
+    private let onClick: (() -> Void)?
+
+    public init(
+        text: String,
+        size: OBRitDropdownMenuItemSize = .large,
+        selected: Bool = false,
+        enabled: Bool = true,
+        onClick: (() -> Void)? = nil
+    ) {
+        self.text = text
+        self.size = size
+        self.selected = selected
+        self.enabled = enabled
+        self.onClick = onClick
+    }
+
+    public var body: some View {
+        Group {
+            if let onClick {
+                Button(action: onClick) {
+                    content
+                }
+                .buttonStyle(.plain)
+                .disabled(!enabled)
+            } else {
+                content
+            }
+        }
+    }
+
+    private var content: some View {
+        Text(text)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity, alignment: textAlignment)
+            .padding(.horizontal, OBRitSpacing.s5)
+            .padding(.vertical, verticalPadding)
+            .frame(width: fixedWidth)
+            .background(selected ? OBRitColors.gray750 : OBRitColors.gray800)
+            .obritTextStyle(textStyle, weight: AtomFontWeight.shared.Medium, color: OBRitColors.common00)
+            .contentShape(Rectangle())
+    }
+
+    private var textStyle: OBRitTypography.TextToken {
+        switch size {
+        case .small:
+            return OBRitTypography.base
+        case .large:
+            return OBRitTypography.xl
+        }
+    }
+
+    private var verticalPadding: CGFloat {
+        switch size {
+        case .small:
+            return OBRitSpacing.s2_5
+        case .large:
+            return OBRitSpacing.s4
+        }
+    }
+
+    private var fixedWidth: CGFloat? {
+        switch size {
+        case .small:
+            return 82
+        case .large:
+            return nil
+        }
+    }
+
+    private var textAlignment: Alignment {
+        switch size {
+        case .small:
+            return .center
+        case .large:
+            return .leading
+        }
+    }
+}
+
 public struct OBRitDropdownMenu: View {
     private let items: [String]
     private let selectedIndex: Int?
+    private let itemSize: OBRitDropdownMenuItemSize
     private let enabled: Bool
     private let onItemClick: (Int) -> Void
 
     public init(
         items: [String],
         selectedIndex: Int? = nil,
+        itemSize: OBRitDropdownMenuItemSize = .large,
         enabled: Bool = true,
         onItemClick: @escaping (Int) -> Void
     ) {
         self.items = items
         self.selectedIndex = selectedIndex
+        self.itemSize = itemSize
         self.enabled = enabled
         self.onItemClick = onItemClick
     }
@@ -118,18 +213,13 @@ public struct OBRitDropdownMenu: View {
     public var body: some View {
         VStack(spacing: 0) {
             ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-                Button {
-                    onItemClick(index)
-                } label: {
-                    Text(item)
-                        .lineLimit(1)
-                        .frame(maxWidth: .infinity, minHeight: OBRitSpacing.s14, alignment: .leading)
-                        .padding(.horizontal, OBRitSpacing.s5)
-                        .background(selectedIndex == index ? OBRitColors.gray750 : OBRitColors.gray800)
-                        .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: OBRitColors.common00)
-                }
-                .buttonStyle(.plain)
-                .disabled(!enabled)
+                OBRitDropdownMenuItem(
+                    text: item,
+                    size: itemSize,
+                    selected: selectedIndex == index,
+                    enabled: enabled,
+                    onClick: { onItemClick(index) }
+                )
             }
         }
         .fixedSize(horizontal: true, vertical: false)

--- a/iosApp/iosApp/DesignSystem/Components/OBRitGnb.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitGnb.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+public enum OBRitGnbItem: CaseIterable, Hashable {
+    case home
+    case list
+}
+
+public struct OBRitGnb: View {
+    private let selected: OBRitGnbItem
+    private let onSelect: (OBRitGnbItem) -> Void
+
+    public init(
+        selected: OBRitGnbItem = .home,
+        onSelect: @escaping (OBRitGnbItem) -> Void
+    ) {
+        self.selected = selected
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            ForEach(OBRitGnbItem.allCases, id: \.self) { item in
+                OBRitGnbButton(
+                    item: item,
+                    selected: selected == item,
+                    onSelect: onSelect
+                )
+            }
+        }
+        .padding(.horizontal, OBRitGnbMetrics.horizontalInset)
+        .padding(.vertical, OBRitSpacing.s1)
+        .frame(width: OBRitGnbMetrics.width, height: OBRitSpacing.s14)
+        .background(OBRitColors.surfaceDefaultDefaultHoverLight)
+        .clipShape(Capsule())
+        .shadow(color: Color.black.opacity(0.24), radius: OBRitSpacing.s6, x: 0, y: OBRitSpacing.s4)
+    }
+}
+
+private struct OBRitGnbButton: View {
+    let item: OBRitGnbItem
+    let selected: Bool
+    let onSelect: (OBRitGnbItem) -> Void
+
+    var body: some View {
+        Button {
+            onSelect(item)
+        } label: {
+            OBRitGnbIcon(item: item, color: iconColor)
+                .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
+                .frame(width: OBRitGnbMetrics.itemWidth, height: OBRitSpacing.s12)
+                .background(selected ? OBRitColors.surfaceDefaultDefaultLight : Color.clear)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private var iconColor: Color {
+        selected ? OBRitColors.gray900 : OBRitColors.common00
+    }
+
+    private var accessibilityLabel: String {
+        switch item {
+        case .home:
+            return "홈"
+        case .list:
+            return "목록"
+        }
+    }
+}
+
+private struct OBRitGnbIcon: View {
+    let item: OBRitGnbItem
+    let color: Color
+
+    var body: some View {
+        switch item {
+        case .home:
+            OBRitGnbHomeShape()
+                .fill(color, style: FillStyle(eoFill: true))
+        case .list:
+            OBRitGnbListIcon(color: color)
+        }
+    }
+}
+
+private struct OBRitGnbHomeShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let w = rect.width
+        let h = rect.height
+
+        path.move(to: CGPoint(x: rect.minX + w * 0.16, y: rect.minY + h * 0.44))
+        path.addLine(to: CGPoint(x: rect.minX + w * 0.50, y: rect.minY + h * 0.16))
+        path.addLine(to: CGPoint(x: rect.minX + w * 0.84, y: rect.minY + h * 0.44))
+        path.addLine(to: CGPoint(x: rect.minX + w * 0.78, y: rect.minY + h * 0.84))
+        path.addLine(to: CGPoint(x: rect.minX + w * 0.22, y: rect.minY + h * 0.84))
+        path.closeSubpath()
+
+        path.addRoundedRect(
+            in: CGRect(
+                x: rect.minX + w * 0.42,
+                y: rect.minY + h * 0.58,
+                width: w * 0.16,
+                height: h * 0.20
+            ),
+            cornerSize: CGSize(width: w * 0.04, height: w * 0.04)
+        )
+        return path
+    }
+}
+
+private struct OBRitGnbListIcon: View {
+    let color: Color
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = min(proxy.size.width, proxy.size.height)
+            let dot = size * 0.14
+            let lineHeight = size * 0.11
+            let lineWidth = size * 0.44
+            let lineX = size * 0.42
+            let rows = [size * 0.24, size * 0.50, size * 0.76]
+
+            ZStack(alignment: .topLeading) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, centerY in
+                    Circle()
+                        .fill(color)
+                        .frame(width: dot, height: dot)
+                        .position(x: size * 0.24, y: centerY)
+                    RoundedRectangle(cornerRadius: lineHeight / 2)
+                        .fill(color)
+                        .frame(width: lineWidth, height: lineHeight)
+                        .position(x: lineX + lineWidth / 2, y: centerY)
+                }
+            }
+            .frame(width: size, height: size)
+        }
+    }
+}
+
+private enum OBRitGnbMetrics {
+    static let width: CGFloat = 122
+    static let itemWidth: CGFloat = 56
+    static let horizontalInset: CGFloat = 5
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitIcons.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitIcons.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum OBRitIconKind {
+public enum OBRitIconKind {
     case check
     case chevronDown
     case exclamation
@@ -9,11 +9,19 @@ enum OBRitIconKind {
     case success
 }
 
-struct OBRitIcon: View {
+public struct OBRitIcon: View {
     let kind: OBRitIconKind
     let color: Color
 
-    var body: some View {
+    public init(
+        kind: OBRitIconKind,
+        color: Color
+    ) {
+        self.kind = kind
+        self.color = color
+    }
+
+    public var body: some View {
         ZStack {
             switch kind {
             case .check:

--- a/iosApp/iosApp/DesignSystem/Components/OBRitIcons.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitIcons.swift
@@ -4,6 +4,7 @@ enum OBRitIconKind {
     case check
     case chevronDown
     case exclamation
+    case info
     case question
     case success
 }
@@ -29,6 +30,12 @@ struct OBRitIcon: View {
                     .fill(color)
                 ExclamationShape()
                     .fill(OBRitColors.common00)
+                    .padding(5)
+            case .info:
+                Circle()
+                    .fill(color)
+                InfoShape()
+                    .fill(OBRitColors.gray900)
                     .padding(5)
             case .question:
                 Circle()
@@ -77,6 +84,31 @@ struct ExclamationShape: Shape {
             cornerSize: CGSize(width: rect.width * 0.08, height: rect.width * 0.08)
         )
         path.addEllipse(in: CGRect(x: midX - rect.width * 0.09, y: rect.minY + rect.height * 0.74, width: rect.width * 0.18, height: rect.width * 0.18))
+        return path
+    }
+}
+
+struct InfoShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let midX = rect.midX
+        path.addEllipse(
+            in: CGRect(
+                x: midX - rect.width * 0.09,
+                y: rect.minY + rect.height * 0.15,
+                width: rect.width * 0.18,
+                height: rect.width * 0.18
+            )
+        )
+        path.addRoundedRect(
+            in: CGRect(
+                x: midX - rect.width * 0.08,
+                y: rect.minY + rect.height * 0.42,
+                width: rect.width * 0.16,
+                height: rect.height * 0.43
+            ),
+            cornerSize: CGSize(width: rect.width * 0.08, height: rect.width * 0.08)
+        )
         return path
     }
 }

--- a/iosApp/iosApp/DesignSystem/Components/OBRitInfo.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitInfo.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import Shared
+
+public enum OBRitInfoSize {
+    case large
+    case small
+}
+
+public enum OBRitInfoState {
+    case info
+    case success
+    case warning
+}
+
+public struct OBRitEssential: View {
+    public init() {}
+
+    public var body: some View {
+        ZStack {
+            AsteriskShape()
+                .stroke(
+                    OBRitColors.red300,
+                    style: StrokeStyle(lineWidth: 1.35, lineCap: .round, lineJoin: .round)
+                )
+                .frame(width: 6, height: 6.725)
+        }
+        .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
+    }
+}
+
+public struct OBRitBullet: View {
+    private let color: Color
+
+    public init(color: Color = OBRitColors.common00) {
+        self.color = color
+    }
+
+    public var body: some View {
+        ZStack {
+            Circle()
+                .fill(color)
+                .frame(width: OBRitSpacing.s1, height: OBRitSpacing.s1)
+        }
+        .frame(width: OBRitSpacing.s5, height: OBRitSpacing.s5)
+    }
+}
+
+public struct OBRitInfo: View {
+    private let text: String
+    private let size: OBRitInfoSize
+    private let state: OBRitInfoState
+
+    public init(
+        text: String,
+        size: OBRitInfoSize = .large,
+        state: OBRitInfoState = .info
+    ) {
+        self.text = text
+        self.size = size
+        self.state = state
+    }
+
+    public var body: some View {
+        HStack(spacing: gap) {
+            OBRitIcon(kind: iconKind, color: color)
+                .frame(width: OBRitSpacing.s4, height: OBRitSpacing.s4)
+
+            Text(text)
+                .lineLimit(1)
+                .obritTextStyle(textToken, weight: AtomFontWeight.shared.SemiBold, color: color)
+        }
+    }
+
+    private var gap: CGFloat {
+        switch size {
+        case .large:
+            return OBRitSpacing.s1_5
+        case .small:
+            return OBRitSpacing.s1
+        }
+    }
+
+    private var textToken: OBRitTypography.TextToken {
+        switch size {
+        case .large:
+            return OBRitTypography.base
+        case .small:
+            return OBRitTypography.small
+        }
+    }
+
+    private var iconKind: OBRitIconKind {
+        switch state {
+        case .info:
+            return .info
+        case .success:
+            return .success
+        case .warning:
+            return .exclamation
+        }
+    }
+
+    private var color: Color {
+        switch state {
+        case .info:
+            return OBRitColors.gray500
+        case .success:
+            return OBRitColors.green300
+        case .warning:
+            return OBRitColors.red300
+        }
+    }
+}
+
+private struct AsteriskShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY + rect.height * 0.24))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY + rect.height * 0.76))
+        path.move(to: CGPoint(x: rect.maxX, y: rect.minY + rect.height * 0.24))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + rect.height * 0.76))
+        return path
+    }
+}
+
+struct OBRitInfo_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading, spacing: OBRitSpacing.s4) {
+            HStack(spacing: OBRitSpacing.s4) {
+                OBRitEssential()
+                OBRitBullet()
+            }
+            OBRitInfo(text: "TEXT", state: .info)
+            OBRitInfo(text: "TEXT", state: .success)
+            OBRitInfo(text: "TEXT", state: .warning)
+            OBRitInfo(text: "TEXT", size: .small, state: .info)
+            OBRitInfo(text: "TEXT", size: .small, state: .success)
+            OBRitInfo(text: "TEXT", size: .small, state: .warning)
+        }
+        .padding(OBRitSpacing.s5)
+        .background(OBRitColors.gray900)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitModal.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitModal.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+import Shared
+
+public enum OBRitModalMode: Sendable {
+    case light
+    case dark
+}
+
+public enum OBRitModalButtonCount: Sendable {
+    case one
+    case two
+}
+
+public enum OBRitModalImageSize: Sendable {
+    case small
+    case large
+
+    var dimension: CGFloat {
+        switch self {
+        case .small:
+            return 68
+        case .large:
+            return 100
+        }
+    }
+}
+
+public struct OBRitModal<ImageContent: View>: View {
+    private let title: String
+    private let description: String
+    private let mode: OBRitModalMode
+    private let buttonCount: OBRitModalButtonCount
+    private let imageSize: OBRitModalImageSize
+    private let showsImage: Bool
+    private let primaryTitle: String
+    private let secondaryTitle: String
+    private let onPrimaryClick: () -> Void
+    private let onSecondaryClick: () -> Void
+    private let image: () -> ImageContent
+
+    public init(
+        title: String,
+        description: String,
+        mode: OBRitModalMode = .light,
+        buttonCount: OBRitModalButtonCount = .two,
+        imageSize: OBRitModalImageSize = .small,
+        showsImage: Bool = true,
+        primaryTitle: String = "CTA",
+        secondaryTitle: String = "CTA",
+        onPrimaryClick: @escaping () -> Void,
+        onSecondaryClick: @escaping () -> Void = {},
+        @ViewBuilder image: @escaping () -> ImageContent
+    ) {
+        self.title = title
+        self.description = description
+        self.mode = mode
+        self.buttonCount = buttonCount
+        self.imageSize = imageSize
+        self.showsImage = showsImage
+        self.primaryTitle = primaryTitle
+        self.secondaryTitle = secondaryTitle
+        self.onPrimaryClick = onPrimaryClick
+        self.onSecondaryClick = onSecondaryClick
+        self.image = image
+    }
+
+    public var body: some View {
+        VStack(spacing: OBRitSpacing.s2_5) {
+            if showsImage {
+                image()
+                    .frame(width: imageSize.dimension, height: imageSize.dimension)
+            }
+
+            VStack(spacing: OBRitSpacing.s4) {
+                VStack(spacing: OBRitSpacing.s2) {
+                    Text(title)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                        .obritTextStyle(OBRitModalMetrics.titleTextToken, weight: AtomFontWeight.shared.Bold, color: titleColor)
+                        .frame(maxWidth: .infinity)
+
+                    Text(description)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                        .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.Medium, color: descriptionColor)
+                        .frame(maxWidth: .infinity)
+                }
+                .frame(width: OBRitModalMetrics.contentWidth)
+
+                buttonRow
+                    .frame(width: OBRitModalMetrics.contentWidth)
+            }
+            .frame(width: OBRitModalMetrics.contentWidth)
+        }
+        .padding(.horizontal, OBRitSpacing.s7)
+        .padding(.vertical, OBRitSpacing.s6)
+        .frame(width: OBRitModalMetrics.modalWidth)
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: OBRitModalMetrics.cornerRadius))
+    }
+
+    @ViewBuilder
+    private var buttonRow: some View {
+        switch buttonCount {
+        case .one:
+            OBRitModalButton(
+                title: primaryTitle,
+                style: .primary,
+                mode: mode,
+                action: onPrimaryClick
+            )
+        case .two:
+            HStack(spacing: OBRitSpacing.s3) {
+                OBRitModalButton(
+                    title: secondaryTitle,
+                    style: .secondary,
+                    mode: mode,
+                    action: onSecondaryClick
+                )
+                .frame(width: OBRitModalMetrics.secondaryButtonWidth)
+
+                OBRitModalButton(
+                    title: primaryTitle,
+                    style: .primary,
+                    mode: mode,
+                    action: onPrimaryClick
+                )
+            }
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch mode {
+        case .light:
+            return OBRitColors.common00
+        case .dark:
+            return OBRitColors.gray800
+        }
+    }
+
+    private var titleColor: Color {
+        switch mode {
+        case .light:
+            return OBRitColors.gray900
+        case .dark:
+            return OBRitColors.common00
+        }
+    }
+
+    private var descriptionColor: Color {
+        switch mode {
+        case .light:
+            return OBRitColors.gray600
+        case .dark:
+            return OBRitColors.gray300
+        }
+    }
+
+}
+
+private enum OBRitModalMetrics {
+    static let modalWidth: CGFloat = 370
+    static let contentWidth: CGFloat = 314
+    static let secondaryButtonWidth: CGFloat = 82
+    static let cornerRadius: CGFloat = 16
+    static let titleTextToken = OBRitTypography.TextToken(size: 20, lineHeight: 30)
+}
+
+public extension OBRitModal where ImageContent == OBRitModalPlaceholderImage {
+    init(
+        title: String,
+        description: String,
+        mode: OBRitModalMode = .light,
+        buttonCount: OBRitModalButtonCount = .two,
+        imageSize: OBRitModalImageSize = .small,
+        showsImage: Bool = true,
+        primaryTitle: String = "CTA",
+        secondaryTitle: String = "CTA",
+        onPrimaryClick: @escaping () -> Void,
+        onSecondaryClick: @escaping () -> Void = {}
+    ) {
+        self.init(
+            title: title,
+            description: description,
+            mode: mode,
+            buttonCount: buttonCount,
+            imageSize: imageSize,
+            showsImage: showsImage,
+            primaryTitle: primaryTitle,
+            secondaryTitle: secondaryTitle,
+            onPrimaryClick: onPrimaryClick,
+            onSecondaryClick: onSecondaryClick
+        ) {
+            OBRitModalPlaceholderImage(size: imageSize)
+        }
+    }
+}
+
+public struct OBRitModalPlaceholderImage: View {
+    private let size: OBRitModalImageSize
+
+    public init(size: OBRitModalImageSize = .small) {
+        self.size = size
+    }
+
+    public var body: some View {
+        ZStack {
+            Color(red: 230 / 255, green: 236 / 255, blue: 239 / 255)
+            VStack(spacing: 3) {
+                Circle()
+                    .fill(Color(red: 201 / 255, green: 210 / 255, blue: 219 / 255))
+                    .frame(width: 18, height: 18)
+
+                HStack(alignment: .top, spacing: 2) {
+                    TriangleShape()
+                        .fill(Color(red: 201 / 255, green: 210 / 255, blue: 219 / 255))
+                        .frame(width: 22, height: 22)
+                    Rectangle()
+                        .fill(Color(red: 201 / 255, green: 210 / 255, blue: 219 / 255))
+                        .frame(width: 17, height: 17)
+                }
+                .frame(width: 41)
+            }
+            .frame(width: 41)
+        }
+        .frame(width: size.dimension, height: size.dimension)
+    }
+}
+
+private enum OBRitModalButtonStyle {
+    case primary
+    case secondary
+}
+
+private struct OBRitModalButton: View {
+    let title: String
+    let style: OBRitModalButtonStyle
+    let mode: OBRitModalMode
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .lineLimit(1)
+                .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.SemiBold, color: contentColor)
+                .frame(maxWidth: .infinity)
+                .frame(height: 46)
+                .padding(.horizontal, OBRitSpacing.s5)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.middle))
+                .contentShape(RoundedRectangle(cornerRadius: OBRitRadius.middle))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .primary:
+            return OBRitColors.green300
+        case .secondary:
+            switch mode {
+            case .light:
+                return OBRitColors.gray100
+            case .dark:
+                return OBRitColors.gray750
+            }
+        }
+    }
+
+    private var contentColor: Color {
+        switch style {
+        case .primary:
+            return OBRitColors.common100
+        case .secondary:
+            switch mode {
+            case .light:
+                return OBRitColors.gray700
+            case .dark:
+                return OBRitColors.gray300
+            }
+        }
+    }
+}
+
+private struct TriangleShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct OBRitModal_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: OBRitSpacing.s5) {
+            HStack(spacing: OBRitSpacing.s5) {
+                OBRitModal(
+                    title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                    description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                    mode: .light,
+                    buttonCount: .two,
+                    imageSize: .small,
+                    onPrimaryClick: {}
+                )
+                OBRitModal(
+                    title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                    description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                    mode: .dark,
+                    buttonCount: .two,
+                    imageSize: .small,
+                    onPrimaryClick: {}
+                )
+            }
+            HStack(spacing: OBRitSpacing.s5) {
+                OBRitModal(
+                    title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                    description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                    mode: .light,
+                    buttonCount: .one,
+                    imageSize: .large,
+                    onPrimaryClick: {}
+                )
+                OBRitModal(
+                    title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                    description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                    mode: .dark,
+                    buttonCount: .one,
+                    imageSize: .large,
+                    onPrimaryClick: {}
+                )
+            }
+        }
+        .padding(OBRitSpacing.s5)
+        .background(OBRitColors.gray900)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitOutlinedTextField.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitOutlinedTextField.swift
@@ -7,12 +7,18 @@ public enum OBRitInputResultState {
     case success
 }
 
-public struct OBRitOutlinedTextField<TrailingContent: View>: View {
+public enum OBRitInputFieldStyle {
+    case `default`
+    case lined
+}
+
+public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: View {
     @Binding private var text: String
     @FocusState private var isFocused: Bool
 
     private let placeholder: String
     private let inputResultState: OBRitInputResultState
+    private let style: OBRitInputFieldStyle
     private let containerColor: Color
     private let maxLength: Int?
     private let supportingText: String
@@ -20,12 +26,14 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
     private let readOnly: Bool
     private let singleLine: Bool
     private let forceFocused: Bool
-    private let trailingContent: () -> TrailingContent
+    private let leadingIcon: () -> LeadingIcon
+    private let trailingIcon: () -> TrailingIcon
 
     public init(
         text: Binding<String>,
         placeholder: String = "",
         inputResultState: OBRitInputResultState = .default,
+        style: OBRitInputFieldStyle = .default,
         containerColor: Color = OBRitColors.gray800,
         maxLength: Int? = nil,
         supportingText: String = "",
@@ -33,11 +41,13 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
         readOnly: Bool = false,
         singleLine: Bool = false,
         forceFocused: Bool = false,
-        @ViewBuilder trailingContent: @escaping () -> TrailingContent
+        @ViewBuilder leadingIcon: @escaping () -> LeadingIcon,
+        @ViewBuilder trailingIcon: @escaping () -> TrailingIcon
     ) {
         self._text = text
         self.placeholder = placeholder
         self.inputResultState = inputResultState
+        self.style = style
         self.containerColor = containerColor
         self.maxLength = maxLength
         self.supportingText = supportingText
@@ -45,12 +55,16 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
         self.readOnly = readOnly
         self.singleLine = singleLine
         self.forceFocused = forceFocused
-        self.trailingContent = trailingContent
+        self.leadingIcon = leadingIcon
+        self.trailingIcon = trailingIcon
     }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: OBRitSpacing.s2) {
             HStack(spacing: OBRitSpacing.s2) {
+                leadingIcon()
+                    .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
+
                 ZStack(alignment: .leading) {
                     if text.isEmpty && !placeholder.isEmpty {
                         Text(placeholder)
@@ -74,17 +88,15 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
                         .obritTextStyle(OBRitTypography.small, weight: AtomFontWeight.shared.Medium, color: counterColor)
                 }
 
-                trailingContent()
+                trailingIcon()
+                    .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
             }
             .frame(minHeight: OBRitSpacing.s14)
             .padding(.horizontal, OBRitSpacing.s5)
             .padding(.vertical, OBRitSpacing.s4)
             .background(containerColor)
             .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.middle))
-            .overlay(
-                RoundedRectangle(cornerRadius: OBRitRadius.middle)
-                    .stroke(borderColor, lineWidth: 1.4)
-            )
+            .overlay { borderOverlay }
 
             if inputResultState != .default && !supportingText.isEmpty {
                 HStack(spacing: OBRitSpacing.s1_5) {
@@ -94,6 +106,14 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
                         .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.SemiBold, color: statusColor)
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var borderOverlay: some View {
+        if let borderStroke {
+            RoundedRectangle(cornerRadius: OBRitRadius.middle)
+                .stroke(borderStroke.color, lineWidth: borderStroke.lineWidth)
         }
     }
 
@@ -115,17 +135,23 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
         }
     }
 
-    private var borderColor: Color {
+    private var borderStroke: (color: Color, lineWidth: CGFloat)? {
         if !enabled {
-            return OBRitColors.gray600
+            return (OBRitColors.gray700, OBRitSpacing.px)
         }
         switch inputResultState {
         case .error:
-            return OBRitColors.red300
+            return (OBRitColors.red300, OBRitSpacing.px)
         case .success:
-            return OBRitColors.green300
+            return (OBRitColors.green300, OBRitSpacing.px)
         case .default:
-            return isFocused || forceFocused ? OBRitColors.common00 : OBRitColors.gray300
+            if isFocused || forceFocused {
+                return (OBRitColors.common00, OBRitSpacing.px)
+            }
+            if style == .lined {
+                return (OBRitColors.gray300, OBRitInputFieldLinedBorderWidth)
+            }
+            return nil
         }
     }
 
@@ -145,11 +171,12 @@ public struct OBRitOutlinedTextField<TrailingContent: View>: View {
     }
 }
 
-public extension OBRitOutlinedTextField where TrailingContent == EmptyView {
+public extension OBRitOutlinedTextField where LeadingIcon == EmptyView, TrailingIcon == EmptyView {
     init(
         text: Binding<String>,
         placeholder: String = "",
         inputResultState: OBRitInputResultState = .default,
+        style: OBRitInputFieldStyle = .default,
         containerColor: Color = OBRitColors.gray800,
         maxLength: Int? = nil,
         supportingText: String = "",
@@ -162,6 +189,40 @@ public extension OBRitOutlinedTextField where TrailingContent == EmptyView {
             text: text,
             placeholder: placeholder,
             inputResultState: inputResultState,
+            style: style,
+            containerColor: containerColor,
+            maxLength: maxLength,
+            supportingText: supportingText,
+            enabled: enabled,
+            readOnly: readOnly,
+            singleLine: singleLine,
+            forceFocused: forceFocused,
+            leadingIcon: { EmptyView() },
+            trailingIcon: { EmptyView() }
+        )
+    }
+}
+
+public extension OBRitOutlinedTextField where LeadingIcon == EmptyView {
+    init(
+        text: Binding<String>,
+        placeholder: String = "",
+        inputResultState: OBRitInputResultState = .default,
+        style: OBRitInputFieldStyle = .default,
+        containerColor: Color = OBRitColors.gray800,
+        maxLength: Int? = nil,
+        supportingText: String = "",
+        enabled: Bool = true,
+        readOnly: Bool = false,
+        singleLine: Bool = false,
+        forceFocused: Bool = false,
+        @ViewBuilder trailingIcon: @escaping () -> TrailingIcon
+    ) {
+        self.init(
+            text: text,
+            placeholder: placeholder,
+            inputResultState: inputResultState,
+            style: style,
             containerColor: containerColor,
             maxLength: maxLength,
             supportingText: supportingText,
@@ -171,6 +232,48 @@ public extension OBRitOutlinedTextField where TrailingContent == EmptyView {
             forceFocused: forceFocused
         ) {
             EmptyView()
+        } trailingIcon: {
+            trailingIcon()
         }
     }
 }
+
+public extension OBRitOutlinedTextField where TrailingIcon == EmptyView {
+    init(
+        text: Binding<String>,
+        placeholder: String = "",
+        inputResultState: OBRitInputResultState = .default,
+        style: OBRitInputFieldStyle = .default,
+        containerColor: Color = OBRitColors.gray800,
+        maxLength: Int? = nil,
+        supportingText: String = "",
+        enabled: Bool = true,
+        readOnly: Bool = false,
+        singleLine: Bool = false,
+        forceFocused: Bool = false,
+        @ViewBuilder leadingIcon: @escaping () -> LeadingIcon,
+        trailingIcon: EmptyView = EmptyView()
+    ) {
+        self.init(
+            text: text,
+            placeholder: placeholder,
+            inputResultState: inputResultState,
+            style: style,
+            containerColor: containerColor,
+            maxLength: maxLength,
+            supportingText: supportingText,
+            enabled: enabled,
+            readOnly: readOnly,
+            singleLine: singleLine,
+            forceFocused: forceFocused,
+            leadingIcon: {
+                leadingIcon()
+            },
+            trailingIcon: {
+                EmptyView()
+            }
+        )
+    }
+}
+
+private let OBRitInputFieldLinedBorderWidth: CGFloat = 1.4

--- a/iosApp/iosApp/DesignSystem/Components/OBRitOutlinedTextField.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitOutlinedTextField.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Shared
+import UIKit
 
 public enum OBRitInputResultState {
     case `default`
@@ -10,6 +11,100 @@ public enum OBRitInputResultState {
 public enum OBRitInputFieldStyle {
     case `default`
     case lined
+}
+
+public enum OBRitTextInputType {
+    case text
+    case name
+    case email
+    case password
+    case number
+    case decimal
+    case phone
+    case url
+    case oneTimeCode
+    case custom(
+        keyboardType: UIKeyboardType,
+        textContentType: UITextContentType? = nil,
+        isSecure: Bool = false,
+        autocapitalization: TextInputAutocapitalization? = nil,
+        autocorrectionDisabled: Bool = false
+    )
+
+    var keyboardType: UIKeyboardType {
+        switch self {
+        case .text, .name, .password, .oneTimeCode:
+            return .default
+        case .email:
+            return .emailAddress
+        case .number:
+            return .numberPad
+        case .decimal:
+            return .decimalPad
+        case .phone:
+            return .phonePad
+        case .url:
+            return .URL
+        case let .custom(keyboardType, _, _, _, _):
+            return keyboardType
+        }
+    }
+
+    var textContentType: UITextContentType? {
+        switch self {
+        case .text, .number, .decimal:
+            return nil
+        case .name:
+            return .name
+        case .email:
+            return .emailAddress
+        case .password:
+            return .password
+        case .phone:
+            return .telephoneNumber
+        case .url:
+            return .URL
+        case .oneTimeCode:
+            return .oneTimeCode
+        case let .custom(_, textContentType, _, _, _):
+            return textContentType
+        }
+    }
+
+    var isSecure: Bool {
+        switch self {
+        case .password:
+            return true
+        case let .custom(_, _, isSecure, _, _):
+            return isSecure
+        default:
+            return false
+        }
+    }
+
+    var autocapitalization: TextInputAutocapitalization? {
+        switch self {
+        case .name:
+            return .words
+        case .email, .password, .url, .oneTimeCode:
+            return .never
+        case let .custom(_, _, _, autocapitalization, _):
+            return autocapitalization
+        default:
+            return nil
+        }
+    }
+
+    var autocorrectionDisabled: Bool {
+        switch self {
+        case .email, .password, .number, .decimal, .phone, .url, .oneTimeCode:
+            return true
+        case let .custom(_, _, _, _, autocorrectionDisabled):
+            return autocorrectionDisabled
+        default:
+            return false
+        }
+    }
 }
 
 public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: View {
@@ -26,6 +121,9 @@ public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: Vie
     private let readOnly: Bool
     private let singleLine: Bool
     private let forceFocused: Bool
+    private let inputType: OBRitTextInputType
+    private let submitLabel: SubmitLabel
+    private let onSubmit: () -> Void
     private let leadingIcon: () -> LeadingIcon
     private let trailingIcon: () -> TrailingIcon
 
@@ -41,6 +139,9 @@ public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: Vie
         readOnly: Bool = false,
         singleLine: Bool = false,
         forceFocused: Bool = false,
+        inputType: OBRitTextInputType = .text,
+        submitLabel: SubmitLabel = .done,
+        onSubmit: @escaping () -> Void = {},
         @ViewBuilder leadingIcon: @escaping () -> LeadingIcon,
         @ViewBuilder trailingIcon: @escaping () -> TrailingIcon
     ) {
@@ -55,6 +156,9 @@ public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: Vie
         self.readOnly = readOnly
         self.singleLine = singleLine
         self.forceFocused = forceFocused
+        self.inputType = inputType
+        self.submitLabel = submitLabel
+        self.onSubmit = onSubmit
         self.leadingIcon = leadingIcon
         self.trailingIcon = trailingIcon
     }
@@ -72,13 +176,7 @@ public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: Vie
                             .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: OBRitColors.gray700)
                     }
 
-                    TextField("", text: $text, axis: singleLine ? .horizontal : .vertical)
-                        .lineLimit(singleLine ? 1 : nil)
-                        .focused($isFocused)
-                        .disabled(!enabled)
-                        .allowsHitTesting(enabled && !readOnly)
-                        .tint(OBRitColors.common00)
-                        .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: contentColor)
+                    inputField
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -107,6 +205,32 @@ public struct OBRitOutlinedTextField<LeadingIcon: View, TrailingIcon: View>: Vie
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private var inputField: some View {
+        if inputType.isSecure {
+            configuredInputField(SecureField("", text: $text))
+                .lineLimit(1)
+        } else {
+            configuredInputField(TextField("", text: $text, axis: singleLine ? .horizontal : .vertical))
+                .lineLimit(singleLine ? 1 : nil)
+        }
+    }
+
+    private func configuredInputField<Field: View>(_ field: Field) -> some View {
+        field
+            .focused($isFocused)
+            .disabled(!enabled)
+            .allowsHitTesting(enabled && !readOnly)
+            .keyboardType(inputType.keyboardType)
+            .textContentType(inputType.textContentType)
+            .textInputAutocapitalization(inputType.autocapitalization)
+            .autocorrectionDisabled(inputType.autocorrectionDisabled)
+            .submitLabel(submitLabel)
+            .onSubmit(onSubmit)
+            .tint(OBRitColors.common00)
+            .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: contentColor)
     }
 
     @ViewBuilder
@@ -183,7 +307,10 @@ public extension OBRitOutlinedTextField where LeadingIcon == EmptyView, Trailing
         enabled: Bool = true,
         readOnly: Bool = false,
         singleLine: Bool = false,
-        forceFocused: Bool = false
+        forceFocused: Bool = false,
+        inputType: OBRitTextInputType = .text,
+        submitLabel: SubmitLabel = .done,
+        onSubmit: @escaping () -> Void = {}
     ) {
         self.init(
             text: text,
@@ -197,6 +324,9 @@ public extension OBRitOutlinedTextField where LeadingIcon == EmptyView, Trailing
             readOnly: readOnly,
             singleLine: singleLine,
             forceFocused: forceFocused,
+            inputType: inputType,
+            submitLabel: submitLabel,
+            onSubmit: onSubmit,
             leadingIcon: { EmptyView() },
             trailingIcon: { EmptyView() }
         )
@@ -216,6 +346,9 @@ public extension OBRitOutlinedTextField where LeadingIcon == EmptyView {
         readOnly: Bool = false,
         singleLine: Bool = false,
         forceFocused: Bool = false,
+        inputType: OBRitTextInputType = .text,
+        submitLabel: SubmitLabel = .done,
+        onSubmit: @escaping () -> Void = {},
         @ViewBuilder trailingIcon: @escaping () -> TrailingIcon
     ) {
         self.init(
@@ -229,7 +362,10 @@ public extension OBRitOutlinedTextField where LeadingIcon == EmptyView {
             enabled: enabled,
             readOnly: readOnly,
             singleLine: singleLine,
-            forceFocused: forceFocused
+            forceFocused: forceFocused,
+            inputType: inputType,
+            submitLabel: submitLabel,
+            onSubmit: onSubmit
         ) {
             EmptyView()
         } trailingIcon: {
@@ -251,6 +387,9 @@ public extension OBRitOutlinedTextField where TrailingIcon == EmptyView {
         readOnly: Bool = false,
         singleLine: Bool = false,
         forceFocused: Bool = false,
+        inputType: OBRitTextInputType = .text,
+        submitLabel: SubmitLabel = .done,
+        onSubmit: @escaping () -> Void = {},
         @ViewBuilder leadingIcon: @escaping () -> LeadingIcon,
         trailingIcon: EmptyView = EmptyView()
     ) {
@@ -266,6 +405,9 @@ public extension OBRitOutlinedTextField where TrailingIcon == EmptyView {
             readOnly: readOnly,
             singleLine: singleLine,
             forceFocused: forceFocused,
+            inputType: inputType,
+            submitLabel: submitLabel,
+            onSubmit: onSubmit,
             leadingIcon: {
                 leadingIcon()
             },

--- a/iosApp/iosApp/DesignSystem/Components/OBRitSelectionControls.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitSelectionControls.swift
@@ -1,4 +1,74 @@
 import SwiftUI
+import Shared
+
+public struct OBRitNumber: View {
+    private let text: String
+    private let selected: Bool
+
+    public init(
+        text: String,
+        selected: Bool = false
+    ) {
+        self.text = text
+        self.selected = selected
+    }
+
+    public var body: some View {
+        Text(text)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.SemiBold, color: contentColor)
+            .frame(width: OBRitSpacing.s7, height: OBRitSpacing.s7)
+            .background(containerColor)
+            .clipShape(Circle())
+    }
+
+    private var containerColor: Color {
+        selected ? OBRitColors.common00 : OBRitColors.gray750
+    }
+
+    private var contentColor: Color {
+        selected ? OBRitColors.common100 : OBRitColors.common00
+    }
+}
+
+public struct OBRitIndicatorDot: View {
+    private let active: Bool
+
+    public init(active: Bool = false) {
+        self.active = active
+    }
+
+    public var body: some View {
+        Circle()
+            .fill(active ? OBRitColors.green300 : OBRitColors.gray700)
+            .frame(width: OBRitSpacing.s2, height: OBRitSpacing.s2)
+    }
+}
+
+public struct OBRitPageIndicator: View {
+    private let count: Int
+    private let selectedIndex: Int
+
+    public init(
+        count: Int,
+        selectedIndex: Int
+    ) {
+        self.count = max(0, count)
+        self.selectedIndex = selectedIndex
+    }
+
+    public var body: some View {
+        HStack(spacing: OBRitSpacing.s2_5) {
+            ForEach(0..<count, id: \.self) { index in
+                OBRitIndicatorDot(active: index == selectedIndex)
+            }
+        }
+        .padding(.horizontal, OBRitSpacing.s5)
+        .padding(.vertical, OBRitSpacing.s3)
+        .frame(maxWidth: .infinity)
+    }
+}
 
 public struct OBRitCheckBox: View {
     private let checked: Bool
@@ -20,13 +90,17 @@ public struct OBRitCheckBox: View {
             onCheckedChange?(!checked)
         } label: {
             ZStack {
-                RoundedRectangle(cornerRadius: 3.2)
-                    .fill(checked ? fillColor : Color.clear)
-                RoundedRectangle(cornerRadius: 3.2)
-                    .stroke(borderColor, lineWidth: checked ? 0 : 1.2)
-                if checked {
-                    OBRitIcon(kind: .check, color: checkColor)
+                ZStack {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(checked ? fillColor : Color.clear)
+                    if checked {
+                        OBRitIcon(kind: .check, color: checkColor)
+                    } else {
+                        RoundedRectangle(cornerRadius: 3)
+                            .stroke(borderColor, lineWidth: 1.2)
+                    }
                 }
+                .frame(width: 18, height: 18)
             }
             .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
             .contentShape(Rectangle())
@@ -38,15 +112,15 @@ public struct OBRitCheckBox: View {
     }
 
     private var fillColor: Color {
-        enabled ? OBRitColors.green300 : OBRitColors.gray600
+        enabled ? OBRitColors.green300 : OBRitColors.green800
     }
 
     private var borderColor: Color {
-        enabled ? OBRitColors.gray300 : OBRitColors.gray600
+        enabled ? OBRitColors.gray400 : OBRitColors.gray700
     }
 
     private var checkColor: Color {
-        enabled ? OBRitColors.gray900 : OBRitColors.gray250
+        OBRitColors.gray900
     }
 }
 
@@ -72,10 +146,11 @@ public struct OBRitRadioButton: View {
             ZStack {
                 Circle()
                     .stroke(ringColor, lineWidth: 1.5)
+                    .frame(width: 21, height: 21)
                 if selected {
                     Circle()
                         .fill(ringColor)
-                        .padding(6)
+                        .frame(width: OBRitSpacing.s3, height: OBRitSpacing.s3)
                 }
             }
             .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
@@ -89,8 +164,8 @@ public struct OBRitRadioButton: View {
 
     private var ringColor: Color {
         if selected {
-            return enabled ? OBRitColors.green300 : OBRitColors.gray600
+            return enabled ? OBRitColors.green300 : OBRitColors.green800
         }
-        return enabled ? OBRitColors.gray300 : OBRitColors.gray600
+        return enabled ? OBRitColors.gray400 : OBRitColors.gray700
     }
 }

--- a/iosApp/iosApp/DesignSystem/Components/OBRitSlider.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitSlider.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+public struct OBRitSlider: View {
+    private let value: Double
+    private let enabled: Bool
+    private let valueRange: ClosedRange<Double>
+    private let onValueChange: (Double) -> Void
+    private let onValueChangeFinished: (() -> Void)?
+
+    public init(
+        value: Double,
+        enabled: Bool = true,
+        valueRange: ClosedRange<Double> = 0...1,
+        onValueChange: @escaping (Double) -> Void,
+        onValueChangeFinished: (() -> Void)? = nil
+    ) {
+        self.value = value
+        self.enabled = enabled
+        self.valueRange = valueRange
+        self.onValueChange = onValueChange
+        self.onValueChangeFinished = onValueChangeFinished
+    }
+
+    public var body: some View {
+        GeometryReader { geometry in
+            let fraction = normalizedFraction
+            let trackWidth = max(0, geometry.size.width - OBRitSliderConstants.thumbSize)
+            let thumbCenterX = OBRitSliderConstants.thumbSize / 2 + trackWidth * fraction
+            let fillWidth = min(geometry.size.width, thumbCenterX + OBRitSliderConstants.trackHeight / 4)
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(OBRitColors.gray800)
+                    .frame(height: OBRitSliderConstants.trackHeight)
+
+                Capsule()
+                    .fill(OBRitColors.green300)
+                    .frame(width: fillWidth, height: OBRitSliderConstants.trackHeight)
+
+                Circle()
+                    .fill(OBRitColors.green300)
+                    .padding(OBRitSpacing.s1)
+                    .background(Circle().fill(OBRitColors.common00))
+                    .frame(width: OBRitSliderConstants.thumbSize, height: OBRitSliderConstants.thumbSize)
+                    .position(x: thumbCenterX, y: geometry.size.height / 2)
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { gesture in
+                        guard enabled else { return }
+                        let location = min(max(gesture.location.x - OBRitSliderConstants.thumbSize / 2, 0), trackWidth)
+                        onValueChange(valueRange.lowerBound + (valueRange.upperBound - valueRange.lowerBound) * location / max(trackWidth, 1))
+                    }
+                    .onEnded { _ in
+                        guard enabled else { return }
+                        onValueChangeFinished?()
+                    }
+            )
+            .opacity(enabled ? 1 : 0.45)
+        }
+        .frame(height: OBRitSliderConstants.thumbSize)
+        .accessibilityElement()
+        .accessibilityLabel("Slider")
+        .accessibilityValue("\(Int(normalizedFraction * 100))%")
+        .accessibilityAdjustableAction { direction in
+            guard enabled else { return }
+            let step = (valueRange.upperBound - valueRange.lowerBound) / 20
+            switch direction {
+            case .increment:
+                onValueChange(min(valueRange.upperBound, value + step))
+            case .decrement:
+                onValueChange(max(valueRange.lowerBound, value - step))
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private var normalizedFraction: Double {
+        let span = valueRange.upperBound - valueRange.lowerBound
+        guard span > 0 else { return 0 }
+        return ((value - valueRange.lowerBound) / span).clamped(to: 0...1)
+    }
+}
+
+private enum OBRitSliderConstants {
+    static let thumbSize = OBRitSpacing.s5
+    static let trackHeight: CGFloat = 4
+}
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitSnackbar.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitSnackbar.swift
@@ -3,9 +3,13 @@ import Shared
 
 public enum OBRitSnackbarIcon {
     case none
-    case `default`
-    case error
-    case success
+    case question
+    case warning
+    case check
+
+    public static let `default`: OBRitSnackbarIcon = .question
+    public static let error: OBRitSnackbarIcon = .warning
+    public static let success: OBRitSnackbarIcon = .check
 }
 
 public struct OBRitSnackbar: View {
@@ -21,19 +25,21 @@ public struct OBRitSnackbar: View {
     }
 
     public var body: some View {
-        HStack(alignment: .top, spacing: 14) {
-            if icon != .none {
+        HStack(alignment: .top, spacing: contentSpacing) {
+            if hasIcon {
                 OBRitIcon(kind: iconKind, color: iconColor)
-                    .frame(width: OBRitSpacing.s5, height: OBRitSpacing.s5)
+                    .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
             }
 
             Text(message)
                 .fixedSize(horizontal: false, vertical: true)
-                .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: OBRitColors.common00)
+                .multilineTextAlignment(hasIcon ? .leading : .center)
+                .frame(width: hasIcon ? nil : OBRitSnackbarMetrics.normalTextWidth)
+                .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.Medium, color: OBRitColors.common00)
         }
-        .padding(.leading, icon == .none ? OBRitSpacing.s5 : 14)
-        .padding(.trailing, OBRitSpacing.s5)
-        .padding(.vertical, icon == .none ? OBRitSpacing.s2 : OBRitSpacing.s2_5)
+        .padding(.leading, hasIcon ? OBRitSpacing.s3 : OBRitSpacing.s4)
+        .padding(.trailing, hasIcon ? OBRitSpacing.s5 : OBRitSpacing.s4)
+        .padding(.vertical, hasIcon ? OBRitSpacing.s3 : OBRitSpacing.s2_5)
         .background(OBRitColors.gray800)
         .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.large))
         .overlay(
@@ -42,15 +48,23 @@ public struct OBRitSnackbar: View {
         )
     }
 
+    private var hasIcon: Bool {
+        icon != .none
+    }
+
+    private var contentSpacing: CGFloat {
+        hasIcon ? OBRitSpacing.s3 : 0
+    }
+
     private var iconKind: OBRitIconKind {
         switch icon {
         case .none:
             return .question
-        case .default:
+        case .question:
             return .question
-        case .error:
+        case .warning:
             return .exclamation
-        case .success:
+        case .check:
             return .success
         }
     }
@@ -59,12 +73,16 @@ public struct OBRitSnackbar: View {
         switch icon {
         case .none:
             return OBRitColors.gray300
-        case .default:
+        case .question:
             return OBRitColors.gray300
-        case .error:
+        case .warning:
             return OBRitColors.red300
-        case .success:
+        case .check:
             return OBRitColors.green300
         }
     }
+}
+
+private enum OBRitSnackbarMetrics {
+    static let normalTextWidth: CGFloat = 173
 }

--- a/iosApp/iosApp/DesignSystem/Components/OBRitStepper.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitStepper.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+import Shared
+
+public enum OBRitStepperSize {
+    case small
+    case large
+}
+
+public struct OBRitStepper: View {
+    private let valueText: String
+    private let size: OBRitStepperSize
+    private let isMinimum: Bool
+    private let onDecrement: (() -> Void)?
+    private let onIncrement: (() -> Void)?
+
+    public init(
+        valueText: String = "N",
+        size: OBRitStepperSize = .small,
+        isMinimum: Bool = false,
+        onDecrement: (() -> Void)? = nil,
+        onIncrement: (() -> Void)? = nil
+    ) {
+        self.valueText = valueText
+        self.size = size
+        self.isMinimum = isMinimum
+        self.onDecrement = onDecrement
+        self.onIncrement = onIncrement
+    }
+
+    public init(
+        value: Int,
+        size: OBRitStepperSize = .small,
+        minimumValue: Int = 0,
+        onDecrement: (() -> Void)? = nil,
+        onIncrement: (() -> Void)? = nil
+    ) {
+        self.valueText = "\(value)"
+        self.size = size
+        self.isMinimum = value <= minimumValue
+        self.onDecrement = onDecrement
+        self.onIncrement = onIncrement
+    }
+
+    public var body: some View {
+        switch size {
+        case .small:
+            smallStepper
+        case .large:
+            largeStepper
+        }
+    }
+
+    private var smallStepper: some View {
+        HStack(spacing: OBRitStepperMetrics.smallGap) {
+            stepperButton(symbol: .minus, size: .small, disabled: isMinimum, action: onDecrement)
+            smallValue
+            stepperButton(symbol: .plus, size: .small, disabled: false, action: onIncrement)
+        }
+        .padding(.vertical, OBRitSpacing.s1)
+        .background(OBRitColors.gray750)
+        .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.small))
+        .shadow(
+            color: isMinimum ? .clear : Color.black.opacity(0.25),
+            radius: 1,
+            x: 0,
+            y: 4
+        )
+    }
+
+    private var smallValue: some View {
+        Text(valueText)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .obritTextStyle(OBRitStepperTypography.lg, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+            .frame(width: OBRitStepperMetrics.smallControlSize, height: OBRitStepperMetrics.smallControlSize)
+            .background(OBRitColors.gray600)
+            .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.small))
+    }
+
+    private var largeStepper: some View {
+        HStack(spacing: OBRitSpacing.s8) {
+            stepperButton(symbol: .minus, size: .large, disabled: isMinimum, action: onDecrement)
+            Text(valueText)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .obritTextStyle(OBRitStepperTypography.xl7, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+                .frame(minWidth: 21)
+            stepperButton(symbol: .plus, size: .large, disabled: false, action: onIncrement)
+        }
+        .frame(width: OBRitStepperMetrics.largeWidth)
+    }
+
+    private func stepperButton(
+        symbol: OBRitStepperSymbol,
+        size: OBRitStepperSize,
+        disabled: Bool,
+        action: (() -> Void)?
+    ) -> some View {
+        Button {
+            guard !disabled else { return }
+            action?()
+        } label: {
+            symbol
+                .stroke(disabled ? OBRitColors.gray600 : OBRitColors.common00, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .frame(width: OBRitSpacing.s6, height: OBRitSpacing.s6)
+                .frame(width: buttonSize(for: size), height: buttonSize(for: size))
+                .background(buttonBackground(for: size))
+                .clipShape(RoundedRectangle(cornerRadius: buttonRadius(for: size)))
+                .contentShape(RoundedRectangle(cornerRadius: buttonRadius(for: size)))
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .accessibilityLabel(symbol.accessibilityLabel)
+    }
+
+    private func buttonSize(for size: OBRitStepperSize) -> CGFloat {
+        switch size {
+        case .small:
+            return OBRitStepperMetrics.smallControlSize
+        case .large:
+            return OBRitStepperMetrics.largeButtonSize
+        }
+    }
+
+    private func buttonRadius(for size: OBRitStepperSize) -> CGFloat {
+        switch size {
+        case .small:
+            return OBRitRadius.small
+        case .large:
+            return OBRitRadius.large
+        }
+    }
+
+    private func buttonBackground(for size: OBRitStepperSize) -> Color {
+        switch size {
+        case .small:
+            return Color.clear
+        case .large:
+            return OBRitColors.gray800
+        }
+    }
+}
+
+private enum OBRitStepperTypography {
+    static let lg = OBRitTypography.TextToken(
+        size: CGFloat(AtomText.Lg.shared.FontSize),
+        lineHeight: CGFloat(AtomText.Lg.shared.LineHeight)
+    )
+    static let xl7 = OBRitTypography.TextToken(
+        size: CGFloat(AtomText.S7xl.shared.FontSize),
+        lineHeight: CGFloat(AtomText.S7xl.shared.LineHeight)
+    )
+}
+
+private enum OBRitStepperMetrics {
+    static let smallGap: CGFloat = OBRitSpacing.s1_5
+    static let smallControlSize: CGFloat = 36
+    static let largeWidth: CGFloat = 197
+    static let largeButtonSize: CGFloat = 56
+}
+
+private enum OBRitStepperSymbol: Shape, Equatable {
+    case minus
+    case plus
+
+    var accessibilityLabel: Text {
+        switch self {
+        case .minus:
+            return Text("decrease")
+        case .plus:
+            return Text("increase")
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX + rect.width * 0.2, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.maxX - rect.width * 0.2, y: rect.midY))
+        if self == .plus {
+            path.move(to: CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.2))
+            path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY - rect.height * 0.2))
+        }
+        return path
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitTab.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitTab.swift
@@ -74,16 +74,25 @@ public struct OBRitTab: View {
             .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
             .padding(.horizontal, OBRitSpacing.s4)
             .padding(.vertical, OBRitSpacing.s3)
+            .background(OBRitTabBackdropBlur())
             .overlay(alignment: .bottom) {
                 Rectangle()
                     .fill(selected ? OBRitColors.green300 : Color.clear)
                     .frame(height: OBRitSpacing.px)
             }
-            .shadow(color: Color.black.opacity(0.16), radius: selected ? 24 : 12, x: 0, y: selected ? 12 : 6)
+            .shadow(color: Color.black.opacity(0.16), radius: selected ? 24 : 12, x: 0, y: OBRitSpacing.s1)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
+}
+
+private struct OBRitTabBackdropBlur: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIVisualEffectView {
+        UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+    }
+
+    func updateUIView(_ uiView: UIVisualEffectView, context: Context) {}
 }
 
 struct OBRitTabs_Previews: PreviewProvider {

--- a/iosApp/iosApp/DesignSystem/Components/OBRitTab.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitTab.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import Shared
+
+public struct OBRitTab: View {
+    private let text: String
+    private let selected: Bool
+    private let number: Int?
+    private let onClick: () -> Void
+
+    public init(
+        text: String,
+        selected: Bool = false,
+        number: Int? = nil,
+        onClick: @escaping () -> Void
+    ) {
+        self.text = text
+        self.selected = selected
+        self.number = number
+        self.onClick = onClick
+    }
+
+    public var body: some View {
+        Button(action: onClick) {
+            HStack(spacing: OBRitSpacing.s2) {
+                Text(text)
+                if let number {
+                    Text("\(number)")
+                }
+            }
+            .lineLimit(1)
+            .obritTextStyle(OBRitTypography.base, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+            .padding(.horizontal, OBRitSpacing.s4)
+            .padding(.vertical, OBRitSpacing.s3)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(selected ? OBRitColors.green300 : Color.clear)
+                    .frame(height: OBRitSpacing.px)
+            }
+            .shadow(color: Color.black.opacity(0.16), radius: selected ? 24 : 12, x: 0, y: selected ? 12 : 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitTab.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitTab.swift
@@ -1,6 +1,49 @@
 import SwiftUI
 import Shared
 
+public struct OBRitTabItem: Hashable {
+    let text: String
+    let number: Int?
+
+    public init(
+        text: String,
+        number: Int? = nil
+    ) {
+        self.text = text
+        self.number = number
+    }
+}
+
+public struct OBRitTabs: View {
+    private let items: [OBRitTabItem]
+    private let selectedIndex: Int
+    private let onSelect: (Int) -> Void
+
+    public init(
+        items: [OBRitTabItem],
+        selectedIndex: Int,
+        onSelect: @escaping (Int) -> Void
+    ) {
+        self.items = items
+        self.selectedIndex = selectedIndex
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                OBRitTab(
+                    text: item.text,
+                    selected: selectedIndex == index,
+                    number: item.number
+                ) {
+                    onSelect(index)
+                }
+            }
+        }
+    }
+}
+
 public struct OBRitTab: View {
     private let text: String
     private let selected: Bool
@@ -40,5 +83,29 @@ public struct OBRitTab: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+}
+
+struct OBRitTabs_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading, spacing: OBRitSpacing.s5) {
+            OBRitTabs(
+                items: Array(repeating: OBRitTabItem(text: "{Text}"), count: 8),
+                selectedIndex: 0,
+                onSelect: { _ in }
+            )
+            OBRitTabs(
+                items: [
+                    OBRitTabItem(text: "{Text}", number: 1),
+                    OBRitTabItem(text: "{Text}", number: 2),
+                    OBRitTabItem(text: "{Text}", number: 3)
+                ],
+                selectedIndex: 1,
+                onSelect: { _ in }
+            )
+        }
+        .padding(OBRitSpacing.s5)
+        .background(OBRitColors.gray900)
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/iosApp/iosApp/DesignSystem/Components/OBRitTitle.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitTitle.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import Shared
+
+public enum OBRitTitleSize {
+    case large
+    case medium
+    case small
+}
+
+public enum OBRitTitleType {
+    case `default`
+    case textOnly
+    case withTag
+}
+
+public struct OBRitTitle: View {
+    private let title: String
+    private let description: String
+    private let tagText: String
+    private let size: OBRitTitleSize
+    private let type: OBRitTitleType
+
+    public init(
+        title: String = "제목을 입력해주세요",
+        description: String = "설명을 입력해주세요. 최대 두 줄까지 입력 가능합니다.",
+        tagText: String = "Text",
+        size: OBRitTitleSize = .large,
+        type: OBRitTitleType = .default
+    ) {
+        self.title = title
+        self.description = description
+        self.tagText = tagText
+        self.size = size
+        self.type = type
+    }
+
+    public var body: some View {
+        VStack(spacing: OBRitSpacing.s3) {
+            content
+        }
+        .padding(.horizontal, OBRitSpacing.s5)
+        .padding(.vertical, OBRitSpacing.s4)
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch type {
+        case .default:
+            VStack(spacing: size == .small ? OBRitSpacing.s1 : OBRitSpacing.s3) {
+                titleText
+                    .multilineTextAlignment(.center)
+                descriptionText
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+        case .textOnly:
+            titleText
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+        case .withTag:
+            VStack(alignment: .leading, spacing: OBRitSpacing.s3) {
+                titleText
+                HStack(spacing: OBRitSpacing.s2) {
+                    OBRitTitleTag(text: tagText)
+                    descriptionText
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var titleText: some View {
+        Text(title)
+            .lineLimit(1)
+            .obritTextStyle(titleToken, weight: AtomFontWeight.shared.Bold, color: OBRitColors.textDefaultDefault)
+    }
+
+    private var descriptionText: some View {
+        Text(description)
+            .obritTextStyle(descriptionToken, weight: AtomFontWeight.shared.Medium, color: OBRitColors.textDefaultSecondary)
+    }
+
+    private var titleToken: OBRitTypography.TextToken {
+        switch size {
+        case .large:
+            return OBRitTypography.s6xl
+        case .medium:
+            return OBRitTypography.s4xl
+        case .small:
+            return OBRitTypography.TextToken(size: OBRitTypography.s2xl.size, lineHeight: OBRitTypography.lg.lineHeight)
+        }
+    }
+
+    private var descriptionToken: OBRitTypography.TextToken {
+        switch size {
+        case .large:
+            return OBRitTypography.xl
+        case .medium:
+            return OBRitTypography.lg
+        case .small:
+            return OBRitTypography.base
+        }
+    }
+}
+
+private struct OBRitTitleTag: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .lineLimit(1)
+            .obritTextStyle(OBRitTypography.xs, weight: OBRitFontWeight.semiBold, color: OBRitColors.textDefaultDarkSecondary)
+            .padding(.horizontal, OBRitSpacing.s2)
+            .padding(.vertical, OBRitSpacing.s1)
+            .background(OBRitColors.backgroundDefaultLightGrayDefault)
+            .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.extraSmall))
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitTooltip.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitTooltip.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+import Shared
+
+public enum OBRitTooltipDirection: Sendable {
+    case top
+    case bottom
+    case left
+    case right
+}
+
+public enum OBRitTooltipAlignment: Sendable {
+    case start
+    case center
+    case end
+}
+
+public struct OBRitTooltip: View {
+    private let text: String
+    private let direction: OBRitTooltipDirection
+    private let alignment: OBRitTooltipAlignment
+
+    public init(
+        text: String,
+        direction: OBRitTooltipDirection = .top,
+        alignment: OBRitTooltipAlignment = .center
+    ) {
+        self.text = text
+        self.direction = direction
+        self.alignment = alignment
+    }
+
+    public var body: some View {
+        switch direction {
+        case .top:
+            VStack(alignment: horizontalStackAlignment, spacing: OBRitSpacing.s0) {
+                popup
+                horizontalArrow(direction: .top)
+            }
+        case .bottom:
+            VStack(alignment: horizontalStackAlignment, spacing: OBRitSpacing.s0) {
+                horizontalArrow(direction: .bottom)
+                popup
+            }
+        case .left:
+            HStack(alignment: verticalStackAlignment, spacing: OBRitSpacing.s0) {
+                popup
+                verticalArrow(direction: .left)
+            }
+        case .right:
+            HStack(alignment: verticalStackAlignment, spacing: OBRitSpacing.s0) {
+                verticalArrow(direction: .right)
+                popup
+            }
+        }
+    }
+
+    private var popup: some View {
+        Text(text)
+            .lineLimit(1)
+            .obritTextStyle(OBRitTypography.small, weight: AtomFontWeight.shared.Medium, color: OBRitColors.common100)
+            .padding(.horizontal, 14)
+            .padding(.vertical, OBRitSpacing.s1_5)
+            .background(OBRitColors.common00)
+            .clipShape(RoundedRectangle(cornerRadius: OBRitRadius.small))
+    }
+
+    private func horizontalArrow(direction: OBRitTooltipDirection) -> some View {
+        HStack(spacing: OBRitSpacing.s0) {
+            if alignment == .end {
+                Spacer(minLength: OBRitSpacing.s0)
+            }
+
+            TooltipArrowShape(direction: direction)
+                .fill(OBRitColors.common00)
+                .frame(width: 10, height: OBRitSpacing.s1_5)
+
+            if alignment == .start {
+                Spacer(minLength: OBRitSpacing.s0)
+            }
+        }
+        .padding(.horizontal, alignment == .center ? OBRitSpacing.s0 : OBRitSpacing.s2)
+        .frame(maxWidth: .infinity)
+        .frame(height: OBRitSpacing.s1_5)
+    }
+
+    private func verticalArrow(direction: OBRitTooltipDirection) -> some View {
+        VStack(spacing: OBRitSpacing.s0) {
+            if alignment == .end {
+                Spacer(minLength: OBRitSpacing.s0)
+            }
+
+            TooltipArrowShape(direction: direction)
+                .fill(OBRitColors.common00)
+                .frame(width: OBRitSpacing.s1_5, height: 10)
+
+            if alignment == .start {
+                Spacer(minLength: OBRitSpacing.s0)
+            }
+        }
+        .frame(width: OBRitSpacing.s1_5)
+        .frame(height: 30)
+    }
+
+    private var horizontalStackAlignment: HorizontalAlignment {
+        switch alignment {
+        case .start:
+            return .leading
+        case .center:
+            return .center
+        case .end:
+            return .trailing
+        }
+    }
+
+    private var verticalStackAlignment: VerticalAlignment {
+        switch alignment {
+        case .start:
+            return .top
+        case .center:
+            return .center
+        case .end:
+            return .bottom
+        }
+    }
+}
+
+private struct TooltipArrowShape: Shape {
+    let direction: OBRitTooltipDirection
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        switch direction {
+        case .top:
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        case .bottom:
+            path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        case .left:
+            path.move(to: CGPoint(x: rect.minX, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        case .right:
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        }
+
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct OBRitTooltip_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: OBRitSpacing.s8) {
+            HStack(spacing: OBRitSpacing.s8) {
+                OBRitTooltip(text: "Place your text here", direction: .top, alignment: .start)
+                OBRitTooltip(text: "Place your text here", direction: .top)
+                OBRitTooltip(text: "Place your text here", direction: .top, alignment: .end)
+            }
+            HStack(spacing: OBRitSpacing.s8) {
+                OBRitTooltip(text: "Place your text here", direction: .bottom, alignment: .start)
+                OBRitTooltip(text: "Place your text here", direction: .bottom)
+                OBRitTooltip(text: "Place your text here", direction: .bottom, alignment: .end)
+            }
+            HStack(spacing: OBRitSpacing.s8) {
+                OBRitTooltip(text: "Place your text here", direction: .right, alignment: .start)
+                OBRitTooltip(text: "Place your text here", direction: .right)
+                OBRitTooltip(text: "Place your text here", direction: .right, alignment: .end)
+            }
+            HStack(spacing: OBRitSpacing.s8) {
+                OBRitTooltip(text: "Place your text here", direction: .left, alignment: .start)
+                OBRitTooltip(text: "Place your text here", direction: .left)
+                OBRitTooltip(text: "Place your text here", direction: .left, alignment: .end)
+            }
+        }
+        .padding(OBRitSpacing.s5)
+        .background(OBRitColors.gray900)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Components/OBRitTopBar.swift
+++ b/iosApp/iosApp/DesignSystem/Components/OBRitTopBar.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+import Shared
+
+public struct OBRitHomeTopBar: View {
+    private let backgroundColor: Bool
+    private let onSearchClick: () -> Void
+    private let onNotificationClick: () -> Void
+    private let onProfileClick: () -> Void
+
+    public init(
+        backgroundColor: Bool = true,
+        onSearchClick: @escaping () -> Void,
+        onNotificationClick: @escaping () -> Void,
+        onProfileClick: @escaping () -> Void
+    ) {
+        self.backgroundColor = backgroundColor
+        self.onSearchClick = onSearchClick
+        self.onNotificationClick = onNotificationClick
+        self.onProfileClick = onProfileClick
+    }
+
+    public var body: some View {
+        TopBarRoot(backgroundColor: backgroundColor) {
+            HStack {
+                Text("OBRit")
+                    .font(.custom("Pretendard-ExtraBold", size: 25))
+                    .foregroundStyle(Color(red: 0.94, green: 0.99, blue: 0.98))
+                    .lineLimit(1)
+                    .accessibilityLabel("OBRit")
+
+                Spacer()
+
+                HStack(spacing: 0) {
+                    TopBarIconButton(symbolName: "magnifyingglass", accessibilityLabel: "검색", action: onSearchClick)
+                    TopBarIconButton(symbolName: "bell", accessibilityLabel: "알림", action: onNotificationClick)
+                    TopBarIconButton(symbolName: "person", accessibilityLabel: "프로필", action: onProfileClick)
+                }
+            }
+            .padding(.leading, OBRitSpacing.s5)
+            .padding(.trailing, OBRitSpacing.s3)
+        }
+    }
+}
+
+public struct OBRitCloseTopBar: View {
+    private let title: String
+    private let backgroundColor: Bool
+    private let showPageTitle: Bool
+    private let showRightButton: Bool
+    private let onCloseClick: () -> Void
+    private let onMoreClick: (() -> Void)?
+
+    public init(
+        title: String,
+        backgroundColor: Bool = true,
+        showPageTitle: Bool = true,
+        showRightButton: Bool = true,
+        onCloseClick: @escaping () -> Void,
+        onMoreClick: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.backgroundColor = backgroundColor
+        self.showPageTitle = showPageTitle
+        self.showRightButton = showRightButton
+        self.onCloseClick = onCloseClick
+        self.onMoreClick = onMoreClick
+    }
+
+    public var body: some View {
+        TopBarWithTitle(
+            title: title,
+            backgroundColor: backgroundColor,
+            showPageTitle: showPageTitle,
+            showRightButton: showRightButton,
+            leadingSymbolName: "xmark",
+            leadingAccessibilityLabel: "닫기",
+            onLeadingClick: onCloseClick,
+            onMoreClick: onMoreClick
+        )
+    }
+}
+
+public struct OBRitDepthTopBar: View {
+    private let title: String
+    private let backgroundColor: Bool
+    private let showPageTitle: Bool
+    private let showRightButton: Bool
+    private let onBackClick: () -> Void
+    private let onMoreClick: (() -> Void)?
+
+    public init(
+        title: String,
+        backgroundColor: Bool = true,
+        showPageTitle: Bool = true,
+        showRightButton: Bool = true,
+        onBackClick: @escaping () -> Void,
+        onMoreClick: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.backgroundColor = backgroundColor
+        self.showPageTitle = showPageTitle
+        self.showRightButton = showRightButton
+        self.onBackClick = onBackClick
+        self.onMoreClick = onMoreClick
+    }
+
+    public var body: some View {
+        TopBarWithTitle(
+            title: title,
+            backgroundColor: backgroundColor,
+            showPageTitle: showPageTitle,
+            showRightButton: showRightButton,
+            leadingSymbolName: "chevron.left",
+            leadingAccessibilityLabel: "뒤로",
+            onLeadingClick: onBackClick,
+            onMoreClick: onMoreClick
+        )
+    }
+}
+
+public struct OBRitSearchTopBar: View {
+    @Binding private var query: String
+    private let placeholder: String
+    private let backgroundColor: Bool
+    private let onBackClick: () -> Void
+
+    public init(
+        query: Binding<String>,
+        placeholder: String = "원하시는 소모품을 검색해보세요",
+        backgroundColor: Bool = true,
+        onBackClick: @escaping () -> Void
+    ) {
+        self._query = query
+        self.placeholder = placeholder
+        self.backgroundColor = backgroundColor
+        self.onBackClick = onBackClick
+    }
+
+    public var body: some View {
+        TopBarRoot(backgroundColor: backgroundColor) {
+            HStack(spacing: OBRitSpacing.s3) {
+                TopBarIconButton(symbolName: "chevron.left", accessibilityLabel: "뒤로", action: onBackClick)
+
+                HStack(spacing: OBRitSpacing.s2) {
+                    TextField("", text: $query, prompt: Text(placeholder).foregroundStyle(OBRitColors.gray700))
+                        .lineLimit(1)
+                        .tint(OBRitColors.common00)
+                        .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Medium, color: OBRitColors.common00)
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: OBRitSpacing.s5, weight: .regular))
+                        .foregroundStyle(OBRitColors.common00)
+                }
+                .padding(.horizontal, OBRitSpacing.s5)
+                .padding(.vertical, OBRitSpacing.s4)
+                .overlay(
+                    RoundedRectangle(cornerRadius: OBRitRadius.middle)
+                        .stroke(OBRitColors.gray300, lineWidth: 1.4)
+                )
+            }
+            .padding(.leading, OBRitSpacing.s3)
+            .padding(.trailing, OBRitSpacing.s3)
+        }
+    }
+}
+
+private struct TopBarWithTitle: View {
+    let title: String
+    let backgroundColor: Bool
+    let showPageTitle: Bool
+    let showRightButton: Bool
+    let leadingSymbolName: String
+    let leadingAccessibilityLabel: String
+    let onLeadingClick: () -> Void
+    let onMoreClick: (() -> Void)?
+
+    var body: some View {
+        TopBarRoot(backgroundColor: backgroundColor) {
+            ZStack {
+                HStack {
+                    TopBarIconButton(
+                        symbolName: leadingSymbolName,
+                        accessibilityLabel: leadingAccessibilityLabel,
+                        action: onLeadingClick
+                    )
+                    Spacer()
+                    if showRightButton, let onMoreClick {
+                        TopBarIconButton(symbolName: "ellipsis", accessibilityLabel: "더보기", action: onMoreClick)
+                            .rotationEffect(.degrees(90))
+                    }
+                }
+                .padding(.horizontal, OBRitSpacing.s3)
+
+                if showPageTitle {
+                    Text(title)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(width: 277)
+                        .obritTextStyle(OBRitTypography.xl, weight: AtomFontWeight.shared.Bold, color: OBRitColors.common00)
+                }
+            }
+        }
+    }
+}
+
+private struct TopBarRoot<Content: View>: View {
+    let backgroundColor: Bool
+    let content: () -> Content
+
+    init(
+        backgroundColor: Bool = true,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.backgroundColor = backgroundColor
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .frame(maxWidth: .infinity)
+            .frame(height: OBRitSpacing.s14)
+            .background(backgroundColor ? OBRitColors.gray900 : Color.clear)
+    }
+}
+
+private struct TopBarIconButton: View {
+    let symbolName: String
+    let accessibilityLabel: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbolName)
+                .font(.system(size: OBRitSpacing.s5, weight: .regular))
+                .foregroundStyle(OBRitColors.common00)
+                .frame(width: OBRitSpacing.s10, height: OBRitSpacing.s10)
+                .contentShape(RoundedRectangle(cornerRadius: OBRitRadius.extraLarge))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/iosApp/iosApp/DesignSystem/Foundation/OBRitDesignTokens.swift
+++ b/iosApp/iosApp/DesignSystem/Foundation/OBRitDesignTokens.swift
@@ -4,19 +4,156 @@ import Shared
 public enum OBRitColors {
     public static let common00 = color(AtomColors.Common.shared.S00)
     public static let common100 = color(AtomColors.Common.shared.S100)
+    public static let commonBlack00_80 = color(AtomColors.CommonOpacityCommonBlack.shared.S00_80)
+    public static let commonBlack00_60 = color(AtomColors.CommonOpacityCommonBlack.shared.S00_60)
+    public static let commonBlack00_40 = color(AtomColors.CommonOpacityCommonBlack.shared.S00_40)
+    public static let commonBlack00_20 = color(AtomColors.CommonOpacityCommonBlack.shared.S00_20)
+    public static let commonWhite00_80 = color(AtomColors.CommonOpacityCommonWhite.shared.S00_80)
+    public static let commonWhite00_60 = color(AtomColors.CommonOpacityCommonWhite.shared.S00_60)
+    public static let commonWhite00_40 = color(AtomColors.CommonOpacityCommonWhite.shared.S00_40)
+    public static let commonWhite00_20 = color(AtomColors.CommonOpacityCommonWhite.shared.S00_20)
+    public static let backgroundDefaultDimDefault = color(SemanticColors.BackgroundDefault.shared.DimDefault)
     public static let gray50 = color(AtomColors.Gray.shared.S50)
     public static let gray100 = color(AtomColors.Gray.shared.S100)
+    public static let gray150 = color(AtomColors.Gray.shared.S150)
+    public static let gray200 = color(AtomColors.Gray.shared.S200)
     public static let gray250 = color(AtomColors.Gray.shared.S250)
     public static let gray300 = color(AtomColors.Gray.shared.S300)
+    public static let gray400 = color(AtomColors.Gray.shared.S400)
     public static let gray450 = color(AtomColors.Gray.shared.S450)
+    public static let gray500 = color(AtomColors.Gray.shared.S500)
     public static let gray600 = color(AtomColors.Gray.shared.S600)
     public static let gray700 = color(AtomColors.Gray.shared.S700)
     public static let gray750 = color(AtomColors.Gray.shared.S750)
     public static let gray800 = color(AtomColors.Gray.shared.S800)
+    public static let gray850 = color(AtomColors.Gray.shared.S850)
     public static let gray900 = color(AtomColors.Gray.shared.S900)
+    public static let grayOpacity700 = color(AtomColors.GrayOpacity.shared.S700)
+    public static let grayOpacity750 = color(AtomColors.GrayOpacity.shared.S750)
+    public static let grayOpacity800 = color(AtomColors.GrayOpacity.shared.S800)
+    public static let grayOpacity850 = color(AtomColors.GrayOpacity.shared.S850)
+    public static let grayOpacity900 = color(AtomColors.GrayOpacity.shared.S900)
+    public static let green50 = color(AtomColors.Green.shared.S50)
+    public static let green100 = color(AtomColors.Green.shared.S100)
+    public static let green150 = color(AtomColors.Green.shared.S150)
+    public static let green200 = color(AtomColors.Green.shared.S200)
+    public static let green250 = color(AtomColors.Green.shared.S250)
+    public static let red100 = color(AtomColors.Red.shared.S100)
+    public static let red250 = color(AtomColors.Red.shared.S250)
     public static let green300 = color(AtomColors.Green.shared.S300)
+    public static let green400 = color(AtomColors.Green.shared.S400)
+    public static let green450 = color(AtomColors.Green.shared.S450)
+    public static let green500 = color(AtomColors.Green.shared.S500)
+    public static let green600 = color(AtomColors.Green.shared.S600)
+    public static let green700 = color(AtomColors.Green.shared.S700)
+    public static let green750 = color(AtomColors.Green.shared.S750)
     public static let green800 = color(AtomColors.Green.shared.S800)
+    public static let green850 = color(AtomColors.Green.shared.S850)
+    public static let green900 = color(AtomColors.Green.shared.S900)
+    public static let red50 = color(AtomColors.Red.shared.S50)
+    public static let red150 = color(AtomColors.Red.shared.S150)
+    public static let red200 = color(AtomColors.Red.shared.S200)
     public static let red300 = color(AtomColors.Red.shared.S300)
+    public static let red400 = color(AtomColors.Red.shared.S400)
+    public static let red450 = color(AtomColors.Red.shared.S450)
+    public static let red500 = color(AtomColors.Red.shared.S500)
+    public static let red600 = color(AtomColors.Red.shared.S600)
+    public static let red700 = color(AtomColors.Red.shared.S700)
+    public static let red750 = color(AtomColors.Red.shared.S750)
+    public static let red800 = color(AtomColors.Red.shared.S800)
+    public static let red850 = color(AtomColors.Red.shared.S850)
+    public static let red900 = color(AtomColors.Red.shared.S900)
+    public static let yellow50 = color(AtomColors.Yellow.shared.S50)
+    public static let yellow100 = color(AtomColors.Yellow.shared.S100)
+    public static let yellow150 = color(AtomColors.Yellow.shared.S150)
+    public static let yellow200 = color(AtomColors.Yellow.shared.S200)
+    public static let yellow250 = color(AtomColors.Yellow.shared.S250)
+    public static let yellow300 = color(AtomColors.Yellow.shared.S300)
+    public static let yellow400 = color(AtomColors.Yellow.shared.S400)
+    public static let yellow450 = color(AtomColors.Yellow.shared.S450)
+    public static let yellow500 = color(AtomColors.Yellow.shared.S500)
+    public static let yellow600 = color(AtomColors.Yellow.shared.S600)
+    public static let yellow700 = color(AtomColors.Yellow.shared.S700)
+    public static let yellow750 = color(AtomColors.Yellow.shared.S750)
+    public static let yellow800 = color(AtomColors.Yellow.shared.S800)
+    public static let yellow850 = color(AtomColors.Yellow.shared.S850)
+    public static let yellow900 = color(AtomColors.Yellow.shared.S900)
+    public static let blue50 = color(AtomColors.Blue.shared.S50)
+    public static let blue100 = color(AtomColors.Blue.shared.S100)
+    public static let blue150 = color(AtomColors.Blue.shared.S150)
+    public static let blue200 = color(AtomColors.Blue.shared.S200)
+    public static let blue250 = color(AtomColors.Blue.shared.S250)
+    public static let blue300 = color(AtomColors.Blue.shared.S300)
+    public static let blue400 = color(AtomColors.Blue.shared.S400)
+    public static let blue450 = color(AtomColors.Blue.shared.S450)
+    public static let blue500 = color(AtomColors.Blue.shared.S500)
+    public static let blue600 = color(AtomColors.Blue.shared.S600)
+    public static let blue700 = color(AtomColors.Blue.shared.S700)
+    public static let blue750 = color(AtomColors.Blue.shared.S750)
+    public static let blue800 = color(AtomColors.Blue.shared.S800)
+    public static let blue850 = color(AtomColors.Blue.shared.S850)
+    public static let blue900 = color(AtomColors.Blue.shared.S900)
+
+    public static let backgroundDefaultDefault = color(SemanticColors.BackgroundDefault.shared.Default)
+    public static let backgroundDefaultDefaultHover = color(SemanticColors.BackgroundDefault.shared.DefaultHover)
+    public static let backgroundDefaultSecondary = color(SemanticColors.BackgroundDefault.shared.Secondary)
+    public static let backgroundDefaultSecondaryHover = color(SemanticColors.BackgroundDefault.shared.SecondaryHover)
+    public static let backgroundDefaultTertiary = color(SemanticColors.BackgroundDefault.shared.Tertiary)
+    public static let backgroundDefaultLightGrayDefault = color(SemanticColors.BackgroundDefault.shared.LightGrayDefault)
+    public static let backgroundDefaultLightGraySecondary = color(SemanticColors.BackgroundDefault.shared.LightGraySecondary)
+    public static let backgroundDefaultLightGrayTertiary = color(SemanticColors.BackgroundDefault.shared.LightGrayTertiary)
+    public static let backgroundDefaultMiddleGrayDefault = color(SemanticColors.BackgroundDefault.shared.MiddleGrayDefault)
+    public static let backgroundDefaultMiddleGraySecondary = color(SemanticColors.BackgroundDefault.shared.MiddleGraySecondary)
+    public static let backgroundDefaultMiddleGrayTertiary = color(SemanticColors.BackgroundDefault.shared.MiddleGrayTertiary)
+    public static let backgroundDefaultDimSecondary = color(SemanticColors.BackgroundDefault.shared.DimSecondary)
+    public static let backgroundDefaultDimTertiary = color(SemanticColors.BackgroundDefault.shared.DimTertiary)
+    public static let backgroundWarningDefault = color(SemanticColors.BackgroundWarning.shared.Default)
+    public static let backgroundWarningHover = color(SemanticColors.BackgroundWarning.shared.Hover)
+    public static let backgroundWarningSecondary = color(SemanticColors.BackgroundWarning.shared.Secondary)
+    public static let backgroundWarningSecondaryHover = color(SemanticColors.BackgroundWarning.shared.SecondaryHover)
+    public static let backgroundPositiveDefault = color(SemanticColors.BackgroundPositive.shared.Default)
+    public static let backgroundPositiveHover = color(SemanticColors.BackgroundPositive.shared.Hover)
+    public static let backgroundPositiveSecondary = color(SemanticColors.BackgroundPositive.shared.Secondary)
+    public static let backgroundPositiveSecondaryHover = color(SemanticColors.BackgroundPositive.shared.SecondaryHover)
+    public static let backgroundDisabledDefault = color(SemanticColors.BackgroundDisabled.shared.Default)
+    public static let textDefaultDefault = color(SemanticColors.TextDefault.shared.Default)
+    public static let textDefaultSecondary = color(SemanticColors.TextDefault.shared.Secondary)
+    public static let textDefaultTertiary = color(SemanticColors.TextDefault.shared.Tertiary)
+    public static let textDefaultDarkDefault = color(SemanticColors.TextDefault.shared.DarkDefault)
+    public static let textDefaultDarkSecondary = color(SemanticColors.TextDefault.shared.DarkSecondary)
+    public static let textDefaultDarkTertiary = color(SemanticColors.TextDefault.shared.DarkTertiary)
+    public static let textWarningDefault = color(SemanticColors.TextWarning.shared.Default)
+    public static let textWarningSecondary = color(SemanticColors.TextWarning.shared.Secondary)
+    public static let textWarningTertiary = color(SemanticColors.TextWarning.shared.Tertiary)
+    public static let textPositiveDefault = color(SemanticColors.TextPositive.shared.Default)
+    public static let textPositiveSecondary = color(SemanticColors.TextPositive.shared.Secondary)
+    public static let textPositiveTertiary = color(SemanticColors.TextPositive.shared.Tertiary)
+    public static let textDisabledDefault = color(SemanticColors.TextDisabled.shared.Default)
+    public static let textDisabledOnDisabled = color(SemanticColors.TextDisabled.shared.OnDisabled)
+    public static let borderDefaultDefault = color(SemanticColors.BorderDefault.shared.Default)
+    public static let borderDefaultSecondary = color(SemanticColors.BorderDefault.shared.Secondary)
+    public static let borderDefaultTertiary = color(SemanticColors.BorderDefault.shared.Tertiary)
+    public static let borderWarningDefault = color(SemanticColors.BorderWarning.shared.Default)
+    public static let borderWarningSecondary = color(SemanticColors.BorderWarning.shared.Secondary)
+    public static let borderWarningTertiary = color(SemanticColors.BorderWarning.shared.Tertiary)
+    public static let borderPositiveDefault = color(SemanticColors.BorderPositive.shared.Default)
+    public static let borderPositiveSecondary = color(SemanticColors.BorderPositive.shared.Secondary)
+    public static let borderPositiveTertiary = color(SemanticColors.BorderPositive.shared.Tertiary)
+    public static let borderDisabledDefault = color(SemanticColors.BorderDisabled.shared.Default)
+    public static let iconDefaultDefault = color(SemanticColors.IconDefault.shared.Default)
+    public static let iconDefaultSecondary = color(SemanticColors.IconDefault.shared.Secondary)
+    public static let iconDefaultTertiary = color(SemanticColors.IconDefault.shared.Tertiary)
+    public static let iconWarningDefault = color(SemanticColors.IconWarning.shared.Default)
+    public static let iconWarningSecondary = color(SemanticColors.IconWarning.shared.Secondary)
+    public static let iconWarningTertiary = color(SemanticColors.IconWarning.shared.Tertiary)
+    public static let iconPositiveDefault = color(SemanticColors.IconPositive.shared.Default)
+    public static let iconPositiveSecondary = color(SemanticColors.IconPositive.shared.Secondary)
+    public static let iconPositiveTertiary = color(SemanticColors.IconPositive.shared.Tertiary)
+    public static let iconDisabledDefault = color(SemanticColors.IconDisabled.shared.Default)
+    public static let iconDisabledOnDisabled = color(SemanticColors.IconDisabled.shared.OnDisabled)
+    public static let surfaceDefaultDefaultDark = color(SemanticColors.SurfaceDefault.shared.DefaultDark)
+    public static let surfaceDefaultDefaultLight = color(SemanticColors.SurfaceDefault.shared.DefaultLight)
+    public static let surfaceDefaultDefaultHoverLight = color(SemanticColors.SurfaceDefault.shared.DefaultHoverLight)
 
     public static func color(_ argb: Int64) -> Color {
         let value = UInt64(bitPattern: argb)
@@ -29,7 +166,9 @@ public enum OBRitColors {
 }
 
 public enum OBRitSpacing {
+    public static let s0 = CGFloat(AtomSpacing.shared.S0)
     public static let px = CGFloat(AtomSpacing.shared.Px)
+    public static let s0_5 = CGFloat(AtomSpacing.shared.S0_5)
     public static let s1 = CGFloat(AtomSpacing.shared.S1)
     public static let s1_5 = CGFloat(AtomSpacing.shared.S1_5)
     public static let s2 = CGFloat(AtomSpacing.shared.S2)
@@ -38,36 +177,74 @@ public enum OBRitSpacing {
     public static let s4 = CGFloat(AtomSpacing.shared.S4)
     public static let s5 = CGFloat(AtomSpacing.shared.S5)
     public static let s6 = CGFloat(AtomSpacing.shared.S6)
+    public static let s7 = CGFloat(AtomSpacing.shared.S7)
+    public static let s8 = CGFloat(AtomSpacing.shared.S8)
+    public static let s9 = CGFloat(AtomSpacing.shared.S9)
+    public static let s10 = CGFloat(AtomSpacing.shared.S10)
+    public static let s11 = CGFloat(AtomSpacing.shared.S11)
+    public static let s12 = CGFloat(AtomSpacing.shared.S12)
     public static let s14 = CGFloat(AtomSpacing.shared.S14)
+    public static let s16 = CGFloat(AtomSpacing.shared.S16)
+    public static let s20 = CGFloat(AtomSpacing.shared.S20)
+    public static let s24 = CGFloat(AtomSpacing.shared.S24)
+    public static let s28 = CGFloat(AtomSpacing.shared.S28)
+    public static let s32 = CGFloat(AtomSpacing.shared.S32)
+    public static let s36 = CGFloat(AtomSpacing.shared.S36)
+    public static let s40 = CGFloat(AtomSpacing.shared.S40)
 }
 
 public enum OBRitRadius {
+    public static let extraSmall = CGFloat(AtomRadius.shared.ExtraSmall)
     public static let small = CGFloat(AtomRadius.shared.Small)
     public static let middle = CGFloat(AtomRadius.shared.Middle)
     public static let large = CGFloat(AtomRadius.shared.Large)
+    public static let extraLarge = CGFloat(AtomRadius.shared.ExtraLarge)
+    public static let bottomSheet = CGFloat(AtomRadius.shared.BottomSheet)
+    public static let exception = CGFloat(AtomRadius.shared.Exception)
+}
+
+public enum OBRitFontFamily {
+    public static let fontSans = AtomFontFamily.shared.FontSans
+}
+
+public enum OBRitFontWeight {
+    public static let regular: Int32 = AtomFontWeight.shared.Regular
+    public static let medium: Int32 = AtomFontWeight.shared.Medium
+    public static let semiBold: Int32 = AtomFontWeight.shared.SemiBold
+    public static let bold: Int32 = AtomFontWeight.shared.Bold
 }
 
 public enum OBRitTypography {
     public struct TextToken {
-        let size: CGFloat
-        let lineHeight: CGFloat
+        public let size: CGFloat
+        public let lineHeight: CGFloat
     }
 
+    public static let s2xs = TextToken(size: CGFloat(AtomText.S2xs.shared.FontSize), lineHeight: CGFloat(AtomText.S2xs.shared.LineHeight))
+    public static let xs = TextToken(size: CGFloat(AtomText.Xs.shared.FontSize), lineHeight: CGFloat(AtomText.Xs.shared.LineHeight))
     public static let small = TextToken(size: CGFloat(AtomText.S.shared.FontSize), lineHeight: CGFloat(AtomText.S.shared.LineHeight))
+    public static let s = small
     public static let base = TextToken(size: CGFloat(AtomText.Base.shared.FontSize), lineHeight: CGFloat(AtomText.Base.shared.LineHeight))
+    public static let lg = TextToken(size: CGFloat(AtomText.Lg.shared.FontSize), lineHeight: CGFloat(AtomText.Lg.shared.LineHeight))
     public static let xl = TextToken(size: CGFloat(AtomText.Xl.shared.FontSize), lineHeight: CGFloat(AtomText.Xl.shared.LineHeight))
+    public static let s2xl = TextToken(size: CGFloat(AtomText.S2xl.shared.FontSize), lineHeight: CGFloat(AtomText.S2xl.shared.LineHeight))
+    public static let s3xl = TextToken(size: CGFloat(AtomText.S3xl.shared.FontSize), lineHeight: CGFloat(AtomText.S3xl.shared.LineHeight))
+    public static let s4xl = TextToken(size: CGFloat(AtomText.S4xl.shared.FontSize), lineHeight: CGFloat(AtomText.S4xl.shared.LineHeight))
+    public static let s5xl = TextToken(size: CGFloat(AtomText.S5xl.shared.FontSize), lineHeight: CGFloat(AtomText.S5xl.shared.LineHeight))
+    public static let s6xl = TextToken(size: CGFloat(AtomText.S6xl.shared.FontSize), lineHeight: CGFloat(AtomText.S6xl.shared.LineHeight))
+    public static let s7xl = TextToken(size: CGFloat(AtomText.S7xl.shared.FontSize), lineHeight: CGFloat(AtomText.S7xl.shared.LineHeight))
 
-    public static func font(_ token: TextToken, weight: Int32 = AtomFontWeight.shared.Regular) -> Font {
+    public static func font(_ token: TextToken, weight: Int32 = OBRitFontWeight.regular) -> Font {
         Font.custom(fontName(for: weight), size: token.size)
     }
 
     public static func fontName(for weight: Int32) -> String {
         switch weight {
-        case AtomFontWeight.shared.Bold:
+        case OBRitFontWeight.bold:
             return "Pretendard-Bold"
-        case AtomFontWeight.shared.SemiBold:
+        case OBRitFontWeight.semiBold:
             return "Pretendard-SemiBold"
-        case AtomFontWeight.shared.Medium:
+        case OBRitFontWeight.medium:
             return "Pretendard-Medium"
         default:
             return "Pretendard-Regular"
@@ -77,6 +254,14 @@ public enum OBRitTypography {
     public static func letterSpacing(for token: TextToken) -> CGFloat {
         token.size * CGFloat(AtomText.shared.LetterSpacing) / 100
     }
+}
+
+public enum OBRitEffects {
+    public static let backgroundBlur0 = CGFloat(AtomEffects.BackgroundBlur.shared.Blur0)
+    public static let backgroundBlur4 = CGFloat(AtomEffects.BackgroundBlur.shared.Blur4)
+    public static let backgroundBlur8 = CGFloat(AtomEffects.BackgroundBlur.shared.Blur8)
+    public static let backgroundBlur12 = CGFloat(AtomEffects.BackgroundBlur.shared.Blur12)
+    public static let backgroundBlur16 = CGFloat(AtomEffects.BackgroundBlur.shared.Blur16)
 }
 
 public struct OBRitTextStyle: ViewModifier {
@@ -96,7 +281,7 @@ public struct OBRitTextStyle: ViewModifier {
 public extension View {
     func obritTextStyle(
         _ token: OBRitTypography.TextToken,
-        weight: Int32 = AtomFontWeight.shared.Regular,
+        weight: Int32 = OBRitFontWeight.regular,
         color: Color
     ) -> some View {
         modifier(OBRitTextStyle(token: token, weight: weight, color: color))

--- a/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
+++ b/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
@@ -18,9 +18,13 @@ struct DesignSystemPreviewGallery: View {
                 previewSection("TopBar") {
                     VStack(spacing: OBRitSpacing.s3) {
                         OBRitHomeTopBar(onSearchClick: {}, onNotificationClick: {}, onProfileClick: {})
+                        OBRitHomeTopBar(backgroundColor: false, onSearchClick: {}, onNotificationClick: {}, onProfileClick: {})
                         OBRitDepthTopBar(title: "PageTitle", onBackClick: {}, onMoreClick: {})
+                        OBRitDepthTopBar(title: "PageTitle", backgroundColor: false, onBackClick: {}, onMoreClick: {})
                         OBRitCloseTopBar(title: "PageTitle", onCloseClick: {}, onMoreClick: {})
+                        OBRitCloseTopBar(title: "PageTitle", showPageTitle: false, showRightButton: false, onCloseClick: {}, onMoreClick: {})
                         OBRitSearchTopBar(query: $searchQuery, onBackClick: {})
+                        OBRitSearchTopBar(query: $searchQuery, backgroundColor: false, onBackClick: {})
                     }
                 }
 
@@ -56,6 +60,19 @@ struct DesignSystemPreviewGallery: View {
                         OBRitRadioButton(selected: false)
                         OBRitRadioButton(selected: true, enabled: false)
                         OBRitRadioButton(selected: false, enabled: false)
+                    }
+                }
+
+                previewSection("Indicators") {
+                    VStack(alignment: .leading, spacing: OBRitSpacing.s4) {
+                        HStack(spacing: OBRitSpacing.s4) {
+                            OBRitNumber(text: "N")
+                            OBRitNumber(text: "N", selected: true)
+                            OBRitIndicatorDot(active: true)
+                            OBRitIndicatorDot()
+                        }
+                        OBRitPageIndicator(count: 18, selectedIndex: 0)
+                            .frame(width: 412)
                     }
                 }
 
@@ -116,6 +133,19 @@ struct DesignSystemPreviewGallery: View {
                         .frame(maxWidth: .infinity)
                 }
 
+                previewSection("Stepper") {
+                    VStack(alignment: .leading, spacing: OBRitSpacing.s8) {
+                        HStack(spacing: OBRitSpacing.s10) {
+                            OBRitStepper(valueText: "N")
+                            OBRitStepper(value: 0)
+                        }
+                        HStack(spacing: OBRitSpacing.s10) {
+                            OBRitStepper(valueText: "N", size: .large)
+                            OBRitStepper(valueText: "N", size: .large, isMinimum: true)
+                        }
+                    }
+                }
+
                 previewSection("Cards") {
                     VStack(spacing: OBRitSpacing.s3) {
                         ScrollView(.horizontal, showsIndicators: false) {
@@ -131,12 +161,84 @@ struct DesignSystemPreviewGallery: View {
                     }
                 }
 
+                previewSection("Modal") {
+                    VStack(spacing: OBRitSpacing.s5) {
+                        HStack(spacing: OBRitSpacing.s5) {
+                            OBRitModal(
+                                title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                                description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                                mode: .light,
+                                buttonCount: .two,
+                                imageSize: .small,
+                                onPrimaryClick: {}
+                            )
+                            OBRitModal(
+                                title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                                description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                                mode: .dark,
+                                buttonCount: .two,
+                                imageSize: .small,
+                                onPrimaryClick: {}
+                            )
+                        }
+                        HStack(spacing: OBRitSpacing.s5) {
+                            OBRitModal(
+                                title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                                description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                                mode: .light,
+                                buttonCount: .one,
+                                imageSize: .large,
+                                onPrimaryClick: {}
+                            )
+                            OBRitModal(
+                                title: "Title Text\n최대 두 줄까지 작성 가능합니다.",
+                                description: "모달의 상세 내용을 작성해주세요.\n최대 두 줄까지 작성 가능합니다.",
+                                mode: .dark,
+                                buttonCount: .one,
+                                imageSize: .large,
+                                onPrimaryClick: {}
+                            )
+                        }
+                    }
+                }
+
                 previewSection("Snackbar") {
                     VStack(alignment: .leading, spacing: OBRitSpacing.s3) {
                         OBRitSnackbar(message: "토스트 팝업 내용을 입력하세요.")
                         OBRitSnackbar(message: "토스트 팝업 내용을 입력하세요.\n토스트 팝업 내용을 입력하세요.", icon: .default)
                         OBRitSnackbar(message: "토스트 팝업 내용을 입력하세요.", icon: .error)
                         OBRitSnackbar(message: "토스트 팝업 내용을 입력하세요.", icon: .success)
+                    }
+                }
+
+                previewSection("Tooltip") {
+                    VStack(spacing: OBRitSpacing.s6) {
+                        HStack(spacing: OBRitSpacing.s8) {
+                            OBRitTooltip(text: "Place your text here", direction: .top, alignment: .start)
+                            OBRitTooltip(text: "Place your text here", direction: .top)
+                            OBRitTooltip(text: "Place your text here", direction: .top, alignment: .end)
+                        }
+                        HStack(spacing: OBRitSpacing.s8) {
+                            OBRitTooltip(text: "Place your text here", direction: .bottom, alignment: .start)
+                            OBRitTooltip(text: "Place your text here", direction: .bottom)
+                            OBRitTooltip(text: "Place your text here", direction: .bottom, alignment: .end)
+                        }
+                        HStack(spacing: OBRitSpacing.s8) {
+                            OBRitTooltip(text: "Place your text here", direction: .right, alignment: .start)
+                            OBRitTooltip(text: "Place your text here", direction: .right)
+                            OBRitTooltip(text: "Place your text here", direction: .right, alignment: .end)
+                        }
+                        HStack(spacing: OBRitSpacing.s8) {
+                            OBRitTooltip(text: "Place your text here", direction: .left, alignment: .start)
+                            OBRitTooltip(text: "Place your text here", direction: .left)
+                            OBRitTooltip(text: "Place your text here", direction: .left, alignment: .end)
+                        }
+                    }
+                }
+
+                previewSection("BottomSheet") {
+                    OBRitBottomSheet {
+                        Color.clear
                     }
                 }
 

--- a/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
+++ b/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
@@ -7,16 +7,42 @@ struct DesignSystemPreviewGallery: View {
     @State private var errorText = "TEXT"
     @State private var successText = "TEXT"
     @State private var trailingText = "TEXT"
+    @State private var searchQuery = ""
+    @State private var sliderValue = 0.5
+    @State private var selectedChipIndex = 0
+    @State private var selectedTabIndex = 0
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: OBRitSpacing.s6) {
+                previewSection("TopBar") {
+                    VStack(spacing: OBRitSpacing.s3) {
+                        OBRitHomeTopBar(onSearchClick: {}, onNotificationClick: {}, onProfileClick: {})
+                        OBRitDepthTopBar(title: "PageTitle", onBackClick: {}, onMoreClick: {})
+                        OBRitCloseTopBar(title: "PageTitle", onCloseClick: {}, onMoreClick: {})
+                        OBRitSearchTopBar(query: $searchQuery, onBackClick: {})
+                    }
+                }
+
                 previewSection("Buttons") {
                     VStack(spacing: OBRitSpacing.s3) {
                         buttonRow(size: .large)
                         buttonRow(size: .middle)
                         buttonRow(size: .small)
                         buttonRow(size: .large, enabled: false)
+                        OBRitFilledTextButton(
+                            text: "Button",
+                            size: .middle,
+                            color: .gray,
+                            enabled: false,
+                            action: {}
+                        ) { contentColor in
+                            Image(systemName: "info.circle")
+                                .foregroundStyle(contentColor)
+                        } trailingIcon: { contentColor in
+                            Image(systemName: "info.circle")
+                                .foregroundStyle(contentColor)
+                        }
                     }
                 }
 
@@ -51,6 +77,57 @@ struct DesignSystemPreviewGallery: View {
                             }
                         }
                         OBRitDropdownMenu(items: Array(repeating: "TEXT", count: 6), selectedIndex: 1, onItemClick: { _ in })
+                    }
+                }
+
+                previewSection("Badges") {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: OBRitSpacing.s2) {
+                            OBRitBadge(text: "Text", type: .warningFilled)
+                            OBRitBadge(text: "Text", type: .gray750Filled)
+                            OBRitBadge(text: "Text", type: .warningWhiteBackgroundFilled)
+                            OBRitBadge(text: "Text", type: .red250Filled)
+                            OBRitBadge(text: "Text", type: .red800Filled)
+                        }
+                    }
+                }
+
+                previewSection("Chips") {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: OBRitSpacing.s2) {
+                            OBRitChip(text: "Text", selected: selectedChipIndex == 0, number: 12) { selectedChipIndex = 0 }
+                            OBRitChip(text: "Text", selected: selectedChipIndex == 1, number: 12) { selectedChipIndex = 1 }
+                            OBRitChip(text: "Text", selected: selectedChipIndex == 2) { selectedChipIndex = 2 }
+                            OBRitChip(text: "Text", selected: selectedChipIndex == 3) { selectedChipIndex = 3 }
+                        }
+                    }
+                }
+
+                previewSection("Tabs") {
+                    HStack(spacing: OBRitSpacing.s2) {
+                        OBRitTab(text: "Text", selected: selectedTabIndex == 0, number: 12) { selectedTabIndex = 0 }
+                        OBRitTab(text: "Text", selected: selectedTabIndex == 1, number: 12) { selectedTabIndex = 1 }
+                        OBRitTab(text: "Text", selected: selectedTabIndex == 2) { selectedTabIndex = 2 }
+                    }
+                }
+
+                previewSection("Slider") {
+                    OBRitSlider(value: sliderValue) { sliderValue = $0 }
+                        .frame(maxWidth: .infinity)
+                }
+
+                previewSection("Cards") {
+                    VStack(spacing: OBRitSpacing.s3) {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: OBRitSpacing.s3) {
+                                OBRitCardGrid(level: .l1, title: "필터", stockCount: 0, daysLabel: "D-day")
+                                OBRitCardGrid(level: .l3, title: "필터", stockCount: 5, daysLabel: "D-day")
+                                OBRitCardGrid(level: .l5, title: "필터", stockCount: 0, daysLabel: "D-7")
+                            }
+                        }
+                        OBRitCardList(level: .l1, title: "필터", daysInUseLabel: "30일", replaceLabel: "교체 D+2", sparesLabel: "여분 5개")
+                        OBRitCardList(level: .l2, title: "필터", daysInUseLabel: "27일", replaceLabel: "교체 D-3", sparesLabel: "여분 0개")
+                        OBRitCardList(level: .l6, title: "필터", daysInUseLabel: "7일", replaceLabel: "교체 D-7", sparesLabel: "여분 5개")
                     }
                 }
 

--- a/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
+++ b/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
@@ -11,10 +11,31 @@ struct DesignSystemPreviewGallery: View {
     @State private var sliderValue = 0.5
     @State private var selectedChipIndex = 0
     @State private var selectedTabIndex = 0
+    @State private var selectedGnbItem = OBRitGnbItem.home
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: OBRitSpacing.s6) {
+                previewSection("GNB") {
+                    HStack(spacing: OBRitSpacing.s10) {
+                        OBRitGnb(selected: selectedGnbItem) { selectedGnbItem = $0 }
+                        OBRitGnb(selected: .list) { _ in }
+                    }
+                }
+
+                previewSection("Title") {
+                    VStack(spacing: OBRitSpacing.s3) {
+                        OBRitTitle(
+                            description: "설명을 입력해주세요. 최대 두 줄까지 입력 가능합니다.\n설명을 입력해주세요. 최대 두 줄까지 입력 가능합니다.",
+                            size: .large,
+                            type: .default
+                        )
+                        OBRitTitle(size: .medium, type: .withTag)
+                        OBRitTitle(size: .small, type: .textOnly)
+                    }
+                    .frame(width: 412)
+                }
+
                 previewSection("TopBar") {
                     VStack(spacing: OBRitSpacing.s3) {
                         OBRitHomeTopBar(onSearchClick: {}, onNotificationClick: {}, onProfileClick: {})

--- a/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
+++ b/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
@@ -40,6 +40,16 @@ struct DesignSystemPreviewGallery: View {
                         OBRitDropdown(value: "", placeholder: "TEXT", expanded: true, onClick: {})
                         OBRitDropdown(value: "TEXT", placeholder: "TEXT", inputState: .error, supportingText: "에러 텍스트를 입력해주세요", onClick: {})
                         OBRitDropdown(value: "", placeholder: "TEXT", enabled: false, onClick: {})
+                        HStack(spacing: OBRitSpacing.s6) {
+                            VStack(spacing: OBRitSpacing.s3) {
+                                OBRitDropdownMenuItem(text: "TEXT", size: .small)
+                                OBRitDropdownMenuItem(text: "TEXT", size: .small, selected: true)
+                            }
+                            VStack(spacing: OBRitSpacing.s3) {
+                                OBRitDropdownMenuItem(text: "TEXT", size: .large)
+                                OBRitDropdownMenuItem(text: "TEXT", size: .large, selected: true)
+                            }
+                        }
                         OBRitDropdownMenu(items: Array(repeating: "TEXT", count: 6), selectedIndex: 1, onItemClick: { _ in })
                     }
                 }

--- a/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
+++ b/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
@@ -121,11 +121,20 @@ struct DesignSystemPreviewGallery: View {
                 }
 
                 previewSection("Tabs") {
-                    HStack(spacing: OBRitSpacing.s2) {
-                        OBRitTab(text: "Text", selected: selectedTabIndex == 0, number: 12) { selectedTabIndex = 0 }
-                        OBRitTab(text: "Text", selected: selectedTabIndex == 1, number: 12) { selectedTabIndex = 1 }
-                        OBRitTab(text: "Text", selected: selectedTabIndex == 2) { selectedTabIndex = 2 }
-                    }
+                    OBRitTabs(
+                        items: [
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}"),
+                            OBRitTabItem(text: "{Text}")
+                        ],
+                        selectedIndex: selectedTabIndex,
+                        onSelect: { selectedTabIndex = $0 }
+                    )
                 }
 
                 previewSection("Slider") {

--- a/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
+++ b/iosApp/iosApp/DesignSystem/Preview/DesignSystemPreviewGallery.swift
@@ -58,12 +58,15 @@ struct DesignSystemPreviewGallery: View {
                         OBRitOutlinedTextField(text: $defaultText, placeholder: "TEXT", maxLength: 30, singleLine: true)
                         OBRitOutlinedTextField(text: $filledText, placeholder: "TEXT", maxLength: 30, singleLine: true)
                         OBRitOutlinedTextField(text: $filledText, placeholder: "TEXT", maxLength: 30, singleLine: true, forceFocused: true)
+                        OBRitOutlinedTextField(text: $defaultText, placeholder: "TEXT", style: .lined, maxLength: 30, singleLine: true)
+                        OBRitOutlinedTextField(text: $filledText, placeholder: "TEXT", style: .lined, maxLength: 30, singleLine: true)
                         OBRitOutlinedTextField(text: $disabledText, placeholder: "TEXT", maxLength: 30, enabled: false, singleLine: true)
                         OBRitOutlinedTextField(text: $errorText, placeholder: "TEXT", inputResultState: .error, maxLength: 30, supportingText: "에러 텍스트를 입력해주세요", singleLine: true)
                         OBRitOutlinedTextField(text: $successText, placeholder: "TEXT", inputResultState: .success, maxLength: 30, supportingText: "완료 텍스트를 입력해주세요", singleLine: true)
                         OBRitOutlinedTextField(text: $trailingText, placeholder: "TEXT", maxLength: 30, singleLine: true) {
+                            OBRitIcon(kind: .question, color: OBRitColors.common00)
+                        } trailingIcon: {
                             OBRitIcon(kind: .success, color: OBRitColors.green300)
-                                .frame(width: OBRitSpacing.s4, height: OBRitSpacing.s4)
                         }
                     }
                 }


### PR DESCRIPTION
### 작업 요약

- Figma 디자인 기준으로 iOS 디자인시스템 Foundation token wrapper와 주요 컴포넌트를 SwiftUI로 이식했습니다.
- Android 디자인시스템 구현과 대조하면서 iOS 누락 컴포넌트 및 variant를 보강했습니다.
- iOS TextField 입력 타입 API와 공용 Icon layer를 추가로 공개해 실제 화면 구현에서 재사용 가능한 API 표면을 넓혔습니다.

### 관련 이슈

- 관련: #41
- Android 후속 이슈: #50, #53, #55, #56, #57, #58, #64, #65, #66, #67

### 변경 사항

- Foundation token
  - shared design-system의 color/semantic color, spacing, radius, typography, font family/weight, effect token을 iOS Swift wrapper로 노출했습니다.
- iOS 컴포넌트
  - TextField: default/lined style, result state, leading/trailing icon, counter, supporting text, focus/disabled border 처리, 입력 타입 API를 추가했습니다.
  - Dropdown: input field, menu, menu item variant를 추가했습니다.
  - Button: filled button/text button size/color/icon variant를 보강했습니다.
  - Selection controls: checkbox, radio button, number, page indicator를 추가했습니다.
  - Feedback/overlay: snackbar, tooltip, modal, bottom sheet를 추가했습니다.
  - Navigation/header: top bar, GNB, title, tab, tabs group을 추가했습니다.
  - Content controls: badge, chip, slider, stepper, card grid/list, info/essential/bullet을 추가했습니다.
  - Icon: 내부 helper였던 OBRitIconKind/OBRitIcon을 public API로 공개했습니다.
- Preview
  - DesignSystemPreviewGallery를 구성해 iOS 디자인시스템 컴포넌트를 한 화면에서 확인할 수 있게 했습니다.

### 변경 이유

- Android 중심으로 구현돼 있던 디자인시스템 컴포넌트를 iOS에서도 같은 기준으로 사용할 수 있게 하기 위함입니다.
- Figma component variant와 iOS SwiftUI API 사이의 간극을 줄이고, 화면 개발자가 token/variant를 직접 재구현하지 않도록 공용 컴포넌트로 제공하기 위함입니다.
- TextField와 Icon은 실제 화면 구현 시 반복될 가능성이 높아 public API로 보강했습니다.

### 영향 범위

- [x] 일반 기능 변경
- [x] UI 변경
- [ ] API 연동 변경
- [x] 공통 컴포넌트 변경
- [ ] 시스템 영향 가능 (`lint`, `gradle`, `manifest`, build config 등)

> 시스템 영향 변경이 포함된 경우 리뷰어 2인 승인 기준을 적용할 수 있습니다.

### 리뷰 요청 포인트

- Figma variant와 iOS 컴포넌트 API가 자연스럽게 대응되는지 확인해주세요.
- Foundation token wrapper가 shared token을 과도하게 재해석하지 않고 SwiftUI에서 쓰기 좋은 형태인지 확인해주세요.
- TextField 입력 타입 API와 public Icon layer가 실제 화면 구현에 충분한지 확인해주세요.
- Android와 차이가 있는 부분은 별도 이슈로 분리했으므로, 이 PR에서는 iOS 구현 범위를 중심으로 봐주세요.

### 테스트 / 검증

- [x] build 통과
  - `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -sdk iphonesimulator -configuration Debug build`
- [ ] ktlint 통과
  - iOS SwiftUI 변경 중심이라 이번 PR에서 실행하지 않았습니다.
- [ ] detekt 통과
  - iOS SwiftUI 변경 중심이라 이번 PR에서 실행하지 않았습니다.
- [ ] unit test 통과
  - 별도 unit test 대상 변경은 없습니다.
- [x] 수동 테스트 완료
  - DesignSystemPreviewGallery 기준으로 컴포넌트 구성을 확인했습니다.

### 스크린샷 / 영상

UI 변경이 있는 경우 첨부해주세요.

| 변경 전 | 변경 후 |
| --- | --- |
| 별도 첨부 없음 | DesignSystemPreviewGallery에서 확인 가능 |

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#이슈번호-기능명`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식 (`feat: ...`, `fix: ...`, `refactor: ...`)
- [x] self-review 완료
- [x] 문서 반영 필요 시 반영 완료
