### PR TITLE
feat: 회원 등록 API 직접 호출 가능하도록 데이터 레이어 구현 (#121)

### DIFF
--- a/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/di/DataModule.kt
+++ b/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/di/DataModule.kt
@@ -10,6 +10,8 @@ import com.obrit.obrit.shared.data.repository.HomeRepository
 import com.obrit.obrit.shared.data.repository.HomeRepositoryImpl
 import com.obrit.obrit.shared.data.repository.ItemRepository
 import com.obrit.obrit.shared.data.repository.ItemRepositoryImpl
+import com.obrit.obrit.shared.data.repository.UserRepository
+import com.obrit.obrit.shared.data.repository.UserRepositoryImpl
 import org.koin.dsl.module
 
 val dataModule =
@@ -19,4 +21,5 @@ val dataModule =
         single<ItemRepository> { ItemRepositoryImpl(get()) }
         single<CategoryRepository> { CategoryRepositoryImpl(get()) }
         single<HomeRepository> { HomeRepositoryImpl(get()) }
+        single<UserRepository> { UserRepositoryImpl(get(), get()) }
     }

--- a/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/UserRepository.kt
+++ b/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/UserRepository.kt
@@ -1,0 +1,5 @@
+package com.obrit.obrit.shared.data.repository
+
+interface UserRepository {
+    suspend fun register(): Result<Long>
+}

--- a/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/UserRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.obrit.obrit.shared.data.repository
+
+import com.obrit.obrit.shared.network.config.DeviceUuidProvider
+import com.obrit.obrit.shared.network.error.runCatchingWith
+import com.obrit.obrit.shared.network.request.user.RegisterUserRequest
+import com.obrit.obrit.shared.network.source.UserRemoteDataSource
+
+internal class UserRepositoryImpl(
+    private val userRemoteDataSource: UserRemoteDataSource,
+    private val deviceUuidProvider: DeviceUuidProvider,
+) : UserRepository {
+    override suspend fun register(): Result<Long> =
+        runCatchingWith {
+            userRemoteDataSource
+                .register(
+                    RegisterUserRequest(
+                        type = UUID_AUTH_TYPE,
+                        value = deviceUuidProvider.get(),
+                    ),
+                ).id
+        }
+}
+
+private const val UUID_AUTH_TYPE = "uuid"

--- a/shared/network/src/androidMain/kotlin/com/obrit/obrit/shared/network/config/UserIdStorage.android.kt
+++ b/shared/network/src/androidMain/kotlin/com/obrit/obrit/shared/network/config/UserIdStorage.android.kt
@@ -1,0 +1,32 @@
+package com.obrit.obrit.shared.network.config
+
+import android.content.Context
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+internal class AndroidUserIdStorage(
+    context: Context,
+) : UserIdStorage {
+    private val preferences =
+        context.applicationContext.getSharedPreferences(USER_PREFERENCES, Context.MODE_PRIVATE)
+
+    override fun load(): Long? {
+        val saved = preferences.getLong(KEY_USER_ID, UNSET)
+        return if (saved == UNSET) null else saved
+    }
+
+    override fun save(userId: Long) {
+        preferences.edit().putLong(KEY_USER_ID, userId).apply()
+    }
+
+    private companion object {
+        const val USER_PREFERENCES = "orbitUser"
+        const val KEY_USER_ID = "userId"
+        const val UNSET = -1L
+    }
+}
+
+internal actual val userIdStorageModule: Module =
+    module {
+        single<UserIdStorage> { AndroidUserIdStorage(get<Context>()) }
+    }

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/config/DeviceUuid.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/config/DeviceUuid.kt
@@ -2,7 +2,7 @@ package com.obrit.obrit.shared.network.config
 
 import org.koin.core.module.Module
 
-internal interface DeviceUuidProvider {
+interface DeviceUuidProvider {
     fun get(): String
 }
 

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/config/UserIdProvider.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/config/UserIdProvider.kt
@@ -10,11 +10,10 @@ internal interface UserIdProvider {
 internal class DefaultUserIdProvider(
     private val deviceUuidProvider: DeviceUuidProvider,
     private val userRemoteDataSource: UserRemoteDataSource,
+    private val userIdStorage: UserIdStorage,
 ) : UserIdProvider {
-    private var cachedUserId: Long? = null
-
     override suspend fun get(): Long {
-        cachedUserId?.let { userId -> return userId }
+        userIdStorage.load()?.let { return it }
 
         val registeredUser =
             userRemoteDataSource.register(
@@ -24,7 +23,7 @@ internal class DefaultUserIdProvider(
                 ),
             )
 
-        cachedUserId = registeredUser.id
+        userIdStorage.save(registeredUser.id)
         return registeredUser.id
     }
 }

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/config/UserIdStorage.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/config/UserIdStorage.kt
@@ -1,0 +1,11 @@
+package com.obrit.obrit.shared.network.config
+
+import org.koin.core.module.Module
+
+internal interface UserIdStorage {
+    fun load(): Long?
+
+    fun save(userId: Long)
+}
+
+internal expect val userIdStorageModule: Module

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/di/NetworkModule.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/di/NetworkModule.kt
@@ -7,7 +7,9 @@ import com.obrit.obrit.shared.network.config.DeviceUuidProvider
 import com.obrit.obrit.shared.network.config.NETWORK_BASE_URL
 import com.obrit.obrit.shared.network.config.NetworkConfiguration
 import com.obrit.obrit.shared.network.config.UserIdProvider
+import com.obrit.obrit.shared.network.config.UserIdStorage
 import com.obrit.obrit.shared.network.config.deviceUuidModule
+import com.obrit.obrit.shared.network.config.userIdStorageModule
 import com.obrit.obrit.shared.network.source.AgentRemoteDataSource
 import com.obrit.obrit.shared.network.source.AgentRemoteDataSourceImpl
 import com.obrit.obrit.shared.network.source.AgentSessionRemoteDataSource
@@ -26,7 +28,7 @@ import org.koin.dsl.module
 
 val networkModule =
     module {
-        includes(deviceUuidModule)
+        includes(deviceUuidModule, userIdStorageModule)
 
         single<NetworkConfiguration> {
             NetworkConfiguration(
@@ -36,7 +38,7 @@ val networkModule =
         single<Json> { createJson() }
         single<HttpClient> { createHttpClient(get(), get()) }
         single<UserRemoteDataSource> { UserRemoteDataSourceImpl(get()) }
-        single<UserIdProvider> { DefaultUserIdProvider(get<DeviceUuidProvider>(), get()) }
+        single<UserIdProvider> { DefaultUserIdProvider(get<DeviceUuidProvider>(), get(), get<UserIdStorage>()) }
         single<AgentRemoteDataSource> { AgentRemoteDataSourceImpl(get()) }
         single<AgentSessionRemoteDataSource> { AgentSessionRemoteDataSourceImpl(get()) }
         single<ItemRemoteDataSource> { ItemRemoteDataSourceImpl(get(), get()) }

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/user/RegisterUserResponse.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/user/RegisterUserResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RegisterUserResponse(
-    @SerialName("id") val id: Long,
+    @SerialName("userId") val id: Long,
     @SerialName("uuid") val uuid: String,
 )

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/source/UserRemoteDataSource.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/source/UserRemoteDataSource.kt
@@ -3,6 +3,6 @@ package com.obrit.obrit.shared.network.source
 import com.obrit.obrit.shared.network.request.user.RegisterUserRequest
 import com.obrit.obrit.shared.network.response.user.RegisterUserResponse
 
-interface UserRemoteDataSource { 
+interface UserRemoteDataSource {
     suspend fun register(request: RegisterUserRequest): RegisterUserResponse
 }

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/source/UserRemoteDataSource.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/source/UserRemoteDataSource.kt
@@ -3,6 +3,6 @@ package com.obrit.obrit.shared.network.source
 import com.obrit.obrit.shared.network.request.user.RegisterUserRequest
 import com.obrit.obrit.shared.network.response.user.RegisterUserResponse
 
-interface UserRemoteDataSource {
+interface UserRemoteDataSource { 
     suspend fun register(request: RegisterUserRequest): RegisterUserResponse
 }

--- a/shared/network/src/iosMain/kotlin/com/obrit/obrit/shared/network/config/UserIdStorage.ios.kt
+++ b/shared/network/src/iosMain/kotlin/com/obrit/obrit/shared/network/config/UserIdStorage.ios.kt
@@ -1,0 +1,28 @@
+package com.obrit.obrit.shared.network.config
+
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import platform.Foundation.NSUserDefaults
+
+internal class IosUserIdStorage : UserIdStorage {
+    private val userDefaults = NSUserDefaults.standardUserDefaults
+
+    override fun load(): Long? {
+        if (userDefaults.objectForKey(KEY_USER_ID) == null) return null
+        return userDefaults.longLongForKey(KEY_USER_ID).takeIf { it != UNSET }
+    }
+
+    override fun save(userId: Long) {
+        userDefaults.setObject(userId, forKey = KEY_USER_ID)
+    }
+
+    private companion object {
+        const val KEY_USER_ID = "userId"
+        const val UNSET = -1L
+    }
+}
+
+internal actual val userIdStorageModule: Module =
+    module {
+        single<UserIdStorage> { IosUserIdStorage() }
+    }


### PR DESCRIPTION
### 작업 요약

- 회원 등록 API 직접 호출 가능하도록 데이터 레이어 구현

### 관련 이슈

- #121 

### 변경 사항

- 회원 등록 API (`/users/`) 직접 호출할 수 있도록 API 데이터 레이어 구현
- 응답 필드 id > userId 변경
- 회원 등록 API 호출 시, SharedPreference로 캐싱

### 변경 이유

- 회원 등록 API 를 다른 API 통해서만 조회 가능하도록 구현돼있어 직접 호출해 테스트하기 위해 데이터 레이어 구현

### 영향 범위

- [x] 일반 기능 변경
- [ ] UI 변경
- [x] API 연동 변경
- [ ] 공통 컴포넌트 변경
- [ ] 시스템 영향 가능 (`lint`, `gradle`, `manifest`, build config 등)

> 시스템 영향 변경이 포함된 경우 리뷰어 2인 승인 기준을 적용할 수 있습니다.

### 리뷰 요청 포인트

-

### 테스트 / 검증

- [x] build 통과
- [x] ktlint 통과
- [x] detekt 통과
- [ ] unit test 통과
- [ ] 수동 테스트 완료

### 스크린샷 / 영상


### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#이슈번호-기능명`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식 (`feat: ...`, `fix: ...`, `refactor: ...`)
- [ ] self-review 완료
- [ ] 문서 반영 필요 시 반영 완료