### PR TITLE
feat: 소모품 수동 등록 API 연동

### DIFF
--- a/android/app/src/main/kotlin/com/obrit/obrit/navigation/RegisterNavigation.kt
+++ b/android/app/src/main/kotlin/com/obrit/obrit/navigation/RegisterNavigation.kt
@@ -3,7 +3,7 @@ package com.obrit.obrit.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
@@ -15,6 +15,7 @@ import com.obrit.feature.register.screen.manual.ManualRegisterNavigation
 import com.obrit.feature.register.screen.manual.ManualRegisterScreen
 import com.obrit.feature.register.screen.manual.PendingCategory
 import com.obrit.obrit.navigation.route.RegisterRoute
+import com.obrit.obrit.shared.model.categories.Category
 
 @Composable
 @Suppress("LongMethod")
@@ -23,7 +24,9 @@ fun RegisterNavigation(
     modifier: Modifier = Modifier,
 ) {
     val registerBackStack = rememberNavBackStack(RegisterRoute.ManualRegister)
-    var pendingCategoryName by rememberSaveable { mutableStateOf<String?>(null) }
+    // DirectRegister → ManualRegister 복귀 시 단발성으로 전달되는 카테고리.
+    // 사용 즉시 null로 초기화되며 process death 복구는 의도적으로 다루지 않는다.
+    var pendingCategory by remember { mutableStateOf<Category?>(null) }
 
     NavDisplay(
         backStack = registerBackStack,
@@ -45,8 +48,8 @@ fun RegisterNavigation(
                             ),
                         pendingCategory =
                             PendingCategory(
-                                name = pendingCategoryName,
-                                onConsumed = { pendingCategoryName = null },
+                                category = pendingCategory,
+                                onConsumed = { pendingCategory = null },
                             ),
                         modifier = Modifier,
                     )
@@ -54,8 +57,8 @@ fun RegisterNavigation(
                 entry<RegisterRoute.DirectRegister> {
                     DirectRegisterScreen(
                         onBack = { registerBackStack.removeLastOrNull() },
-                        onRegister = { name, _ ->
-                            pendingCategoryName = name
+                        onRegister = { category ->
+                            pendingCategory = category
                             registerBackStack.removeLastOrNull()
                         },
                         modifier = Modifier,

--- a/android/feature/register/build.gradle.kts
+++ b/android/feature/register/build.gradle.kts
@@ -11,4 +11,7 @@ dependencies {
     implementation(projects.shared.designSystem)
     implementation(projects.shared.data)
     api(projects.shared.model)
+
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
 }

--- a/android/feature/register/build.gradle.kts
+++ b/android/feature/register/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
     implementation(projects.android.core.ui)
     implementation(projects.android.core.designsystem)
     implementation(projects.shared.designSystem)
+    implementation(projects.shared.data)
+    api(projects.shared.model)
 }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategoryListArea.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategoryListArea.kt
@@ -79,6 +79,7 @@ private fun CategoryList(
         items(items, key = { it.id }) { category ->
             CategoryListItem(
                 name = category.name,
+                iconUrl = category.iconUrl,
                 addedCount = category.itemCount,
                 selected = category.id == selectedId,
                 onClick = { onCategorySelect(category) },

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategoryListArea.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategoryListArea.kt
@@ -26,17 +26,18 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
+import com.obrit.obrit.shared.model.categories.Category
 
 internal data class CategoryListAreaState(
     val isEmptyResult: Boolean,
-    val items: List<String>,
-    val selectedName: String,
+    val items: List<Category>,
+    val selectedId: Long?,
 )
 
 @Composable
 internal fun CategoryListArea(
     state: CategoryListAreaState,
-    onCategorySelect: (String) -> Unit,
+    onCategorySelect: (Category) -> Unit,
     onDirectRegisterClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -50,7 +51,7 @@ internal fun CategoryListArea(
         } else {
             CategoryList(
                 items = state.items,
-                selectedName = state.selectedName,
+                selectedId = state.selectedId,
                 onCategorySelect = onCategorySelect,
             )
             CategoryListBottomFade(color = colors.gray900)
@@ -60,9 +61,9 @@ internal fun CategoryListArea(
 
 @Composable
 private fun CategoryList(
-    items: List<String>,
-    selectedName: String,
-    onCategorySelect: (String) -> Unit,
+    items: List<Category>,
+    selectedId: Long?,
+    onCategorySelect: (Category) -> Unit,
 ) {
     val listState = rememberLazyListState()
     val listFlingGuard = remember(listState) { listFlingGuardConnection(listState) }
@@ -75,12 +76,12 @@ private fun CategoryList(
         verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
         contentPadding = PaddingValues(bottom = CATEGORY_LIST_BOTTOM_FADE),
     ) {
-        items(items, key = { it }) { name ->
+        items(items, key = { it.id }) { category ->
             CategoryListItem(
-                name = name,
-                addedCount = 0,
-                selected = name == selectedName,
-                onClick = { onCategorySelect(name) },
+                name = category.name,
+                addedCount = category.itemCount,
+                selected = category.id == selectedId,
+                onClick = { onCategorySelect(category) },
             )
         }
     }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategoryListUi.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategoryListUi.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -21,6 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.obrit.android.core.designsystem.R
 import com.obrit.android.core.designsystem.component.radiobutton.OBRitRadioButton
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
@@ -31,6 +33,7 @@ import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
 @Composable
 internal fun CategoryListItem(
     name: String,
+    iconUrl: String,
     addedCount: Int,
     selected: Boolean,
     onClick: () -> Unit,
@@ -53,7 +56,13 @@ internal fun CategoryListItem(
                     .size(CATEGORY_ITEM_IMAGE_SIZE)
                     .clip(CircleShape)
                     .background(colors.gray750),
-        )
+        ) {
+            AsyncImage(
+                model = iconUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
         CategoryListItemText(
             name = name,
             addedCount = addedCount,

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategorySelectionBottomSheet.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategorySelectionBottomSheet.kt
@@ -39,18 +39,18 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import com.obrit.android.core.designsystem.component.bottomsheet.OBRitBottomSheet
 import com.obrit.android.core.designsystem.theme.OBRitTheme
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
+import com.obrit.obrit.shared.model.categories.Category
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun CategorySelectionBottomSheet(
-    initialSelected: String,
-    onConfirm: (String) -> Unit,
+    categories: List<Category>,
+    initialSelectedId: Long?,
+    onConfirm: (Category) -> Unit,
     onDismissRequest: () -> Unit,
     onDirectRegisterClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -66,10 +66,10 @@ internal fun CategorySelectionBottomSheet(
 
     // M3 ModalBottomSheet의 sheet container가 IME에 자동 반응(CTA 떠오름 + 진동)하는 의도된 동작을
     // disable할 공식 API가 없어, 직접 Dialog로 wrapper를 구성.
-    Dialog(
+    androidx.compose.ui.window.Dialog(
         onDismissRequest = onDismissRequest,
         properties =
-            DialogProperties(
+            androidx.compose.ui.window.DialogProperties(
                 usePlatformDefaultWidth = false,
                 decorFitsSystemWindows = false,
                 dismissOnClickOutside = false,
@@ -78,7 +78,8 @@ internal fun CategorySelectionBottomSheet(
         CategorySheetScrim(modifier = modifier, onDismiss = onDismissRequest) {
             CategorySheetContainer(state = anchoredState, flingBehavior = flingBehavior) {
                 CategorySelectionBottomSheetContent(
-                    initialSelected = initialSelected,
+                    categories = categories,
+                    initialSelectedId = initialSelectedId,
                     onConfirm = onConfirm,
                     onDirectRegisterClick = onDirectRegisterClick,
                 )
@@ -164,16 +165,17 @@ internal enum class SheetDragValue { Expanded, Hidden }
 @Composable
 @Suppress("LongMethod")
 private fun CategorySelectionBottomSheetContent(
-    initialSelected: String,
-    onConfirm: (String) -> Unit,
+    categories: List<Category>,
+    initialSelectedId: Long?,
+    onConfirm: (Category) -> Unit,
     onDirectRegisterClick: () -> Unit,
 ) {
     var query by rememberSaveable { mutableStateOf("") }
     var confirmedQuery by rememberSaveable { mutableStateOf("") }
-    var selectedName by rememberSaveable(initialSelected) { mutableStateOf(initialSelected) }
+    var selectedId by rememberSaveable(initialSelectedId) { mutableStateOf(initialSelectedId) }
     val keyboard = LocalSoftwareKeyboardController.current
-    val displayList = rememberCategoryDisplayList(confirmedQuery)
-    val suggestions = rememberCategorySuggestions(query, confirmedQuery)
+    val displayList = rememberCategoryDisplayList(categories, confirmedQuery)
+    val suggestions = rememberCategorySuggestions(categories, query, confirmedQuery)
     val isEmptyResult = confirmedQuery.isNotBlank() && displayList.isEmpty()
     var searchFieldBottomPx by remember { mutableIntStateOf(0) }
     val commitSearch: (String) -> Unit = { v ->
@@ -188,7 +190,7 @@ private fun CategorySelectionBottomSheetContent(
                     query = query,
                     isEmptyResult = isEmptyResult,
                     displayList = displayList,
-                    selectedName = selectedName,
+                    selectedId = selectedId,
                 ),
             actions =
                 CategorySheetMainColumnActions(
@@ -197,9 +199,12 @@ private fun CategorySelectionBottomSheetContent(
                         if (newValue.isEmpty() && confirmedQuery.isNotEmpty()) confirmedQuery = ""
                     },
                     onSearch = { commitSearch(query) },
-                    onCategorySelect = { selectedName = it },
+                    onCategorySelect = { selectedId = it.id },
                     onDirectRegisterClick = onDirectRegisterClick,
-                    onConfirm = { onConfirm(selectedName) },
+                    onConfirm = {
+                        val picked = categories.firstOrNull { it.id == selectedId }
+                        if (picked != null) onConfirm(picked)
+                    },
                     onSearchFieldSized = { searchFieldBottomPx = it },
                 ),
             suggestions = suggestions,
@@ -213,7 +218,7 @@ private fun CategorySelectionBottomSheetContent(
 private fun CategorySheetBody(
     state: CategorySheetMainColumnState,
     actions: CategorySheetMainColumnActions,
-    suggestions: List<String>,
+    suggestions: List<Category>,
     onSuggestionPick: (String) -> Unit,
     searchFieldBottomPx: Int,
 ) {
@@ -222,7 +227,7 @@ private fun CategorySheetBody(
         CategorySheetMainColumn(state = state, actions = actions)
         if (suggestions.isNotEmpty()) {
             CategorySearchSuggestionsOverlay(
-                suggestions = suggestions,
+                suggestions = suggestions.map { it.name },
                 query = state.query,
                 onPick = onSuggestionPick,
                 topOffsetPx = searchFieldBottomPx,
@@ -234,14 +239,14 @@ private fun CategorySheetBody(
 internal data class CategorySheetMainColumnState(
     val query: String,
     val isEmptyResult: Boolean,
-    val displayList: List<String>,
-    val selectedName: String,
+    val displayList: List<Category>,
+    val selectedId: Long?,
 )
 
 internal data class CategorySheetMainColumnActions(
     val onQueryChange: (String) -> Unit,
     val onSearch: () -> Unit,
-    val onCategorySelect: (String) -> Unit,
+    val onCategorySelect: (Category) -> Unit,
     val onDirectRegisterClick: () -> Unit,
     val onConfirm: () -> Unit,
     val onSearchFieldSized: (Int) -> Unit,
@@ -273,7 +278,7 @@ private fun CategorySheetMainColumn(
                 CategoryListAreaState(
                     isEmptyResult = state.isEmptyResult,
                     items = state.displayList,
-                    selectedName = state.selectedName,
+                    selectedId = state.selectedId,
                 ),
             onCategorySelect = actions.onCategorySelect,
             onDirectRegisterClick = actions.onDirectRegisterClick,
@@ -281,7 +286,7 @@ private fun CategorySheetMainColumn(
         )
         CategoryConfirmButton(
             isEmptyResult = state.isEmptyResult,
-            enabled = !state.isEmptyResult && state.selectedName.isNotBlank(),
+            enabled = !state.isEmptyResult && state.selectedId != null,
             onClick = actions.onConfirm,
         )
     }
@@ -292,7 +297,8 @@ private fun CategorySheetMainColumn(
 private fun CategorySelectionBottomSheetEmptyPreview() {
     OBRitTheme(dynamicColor = false) {
         CategorySelectionBottomSheetContent(
-            initialSelected = "",
+            categories = emptyList(),
+            initialSelectedId = null,
             onConfirm = {},
             onDirectRegisterClick = {},
         )
@@ -303,8 +309,14 @@ private fun CategorySelectionBottomSheetEmptyPreview() {
 @Composable
 private fun CategorySelectionBottomSheetSelectedPreview() {
     OBRitTheme(dynamicColor = false) {
+        val sample =
+            listOf(
+                Category(id = 1, name = "정수기 필터", iconUrl = "", itemCount = 0, totalSpareQuantity = 0),
+                Category(id = 2, name = "칫솔", iconUrl = "", itemCount = 0, totalSpareQuantity = 0),
+            )
         CategorySelectionBottomSheetContent(
-            initialSelected = "정수기 필터",
+            categories = sample,
+            initialSelectedId = 1L,
             onConfirm = {},
             onDirectRegisterClick = {},
         )

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategorySelectionBottomSheet.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategorySelectionBottomSheet.kt
@@ -45,17 +45,21 @@ import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
 import com.obrit.obrit.shared.model.categories.Category
 import kotlin.math.roundToInt
 
+internal data class CategorySheetActions(
+    val onConfirm: (Category) -> Unit,
+    val onDismiss: () -> Unit,
+    val onDirectRegister: () -> Unit,
+)
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun CategorySelectionBottomSheet(
     categories: List<Category>,
     initialSelectedId: Long?,
-    onConfirm: (Category) -> Unit,
-    onDismissRequest: () -> Unit,
-    onDirectRegisterClick: () -> Unit,
+    actions: CategorySheetActions,
     modifier: Modifier = Modifier,
 ) {
-    val anchoredState = rememberSheetDragState(onDismissRequest)
+    val anchoredState = rememberSheetDragState(actions.onDismiss)
     // 새 API: thresholds/specs는 flingBehavior로 옮김. velocityThreshold는 default 사용 (M3 표준 유사).
     val flingBehavior =
         AnchoredDraggableDefaults.flingBehavior(
@@ -67,7 +71,7 @@ internal fun CategorySelectionBottomSheet(
     // M3 ModalBottomSheet의 sheet container가 IME에 자동 반응(CTA 떠오름 + 진동)하는 의도된 동작을
     // disable할 공식 API가 없어, 직접 Dialog로 wrapper를 구성.
     androidx.compose.ui.window.Dialog(
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = actions.onDismiss,
         properties =
             androidx.compose.ui.window.DialogProperties(
                 usePlatformDefaultWidth = false,
@@ -75,13 +79,13 @@ internal fun CategorySelectionBottomSheet(
                 dismissOnClickOutside = false,
             ),
     ) {
-        CategorySheetScrim(modifier = modifier, onDismiss = onDismissRequest) {
+        CategorySheetScrim(modifier = modifier, onDismiss = actions.onDismiss) {
             CategorySheetContainer(state = anchoredState, flingBehavior = flingBehavior) {
                 CategorySelectionBottomSheetContent(
                     categories = categories,
                     initialSelectedId = initialSelectedId,
-                    onConfirm = onConfirm,
-                    onDirectRegisterClick = onDirectRegisterClick,
+                    onConfirm = actions.onConfirm,
+                    onDirectRegisterClick = actions.onDirectRegister,
                 )
             }
         }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategorySheetState.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/category/CategorySheetState.kt
@@ -2,44 +2,35 @@ package com.obrit.feature.register.screen.category
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.obrit.obrit.shared.model.categories.Category
 
 @Composable
-internal fun rememberCategoryDisplayList(confirmedQuery: String): List<String> =
-    remember(confirmedQuery) {
+internal fun rememberCategoryDisplayList(
+    categories: List<Category>,
+    confirmedQuery: String,
+): List<Category> =
+    remember(categories, confirmedQuery) {
         if (confirmedQuery.isBlank()) {
-            MOCK_CATEGORIES
+            categories
         } else {
-            MOCK_CATEGORIES.filter { it.contains(confirmedQuery, ignoreCase = true) }
+            categories.filter { it.name.contains(confirmedQuery, ignoreCase = true) }
         }
     }
 
 @Composable
 internal fun rememberCategorySuggestions(
+    categories: List<Category>,
     query: String,
     confirmedQuery: String,
-): List<String> =
-    remember(query, confirmedQuery) {
+): List<Category> =
+    remember(categories, query, confirmedQuery) {
         if (query.isBlank() || query == confirmedQuery) {
             emptyList()
         } else {
-            MOCK_CATEGORIES
-                .filter { it.contains(query, ignoreCase = true) }
+            categories
+                .filter { it.name.contains(query, ignoreCase = true) }
                 .take(MAX_SUGGESTIONS)
         }
     }
 
 private const val MAX_SUGGESTIONS = 3
-
-internal val MOCK_CATEGORIES =
-    listOf(
-        "면도기",
-        "정수기 필터",
-        "칫솔",
-        "치약",
-        "세탁 세제",
-        "수건",
-        "샤워기 필터",
-        "수세미",
-        "주방세제",
-        "휴지",
-    )

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterIconGrid.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterIconGrid.kt
@@ -17,20 +17,21 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
+import com.obrit.obrit.shared.model.categories.CategoryIcon
 
 @Composable
 internal fun IconGridField(
     label: String,
-    totalCount: Int,
-    selectedIndex: Int?,
-    onSelect: (Int) -> Unit,
+    icons: List<CategoryIcon>,
+    selectedIconId: Long?,
+    onSelect: (Long) -> Unit,
     headerSlot: @Composable (String) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(AtomSpacing.S3.dp)) {
         headerSlot(label)
         IconGrid(
-            totalCount = totalCount,
-            selectedIndex = selectedIndex,
+            icons = icons,
+            selectedIconId = selectedIconId,
             onSelect = onSelect,
         )
     }
@@ -38,10 +39,11 @@ internal fun IconGridField(
 
 @Composable
 private fun IconGrid(
-    totalCount: Int,
-    selectedIndex: Int?,
-    onSelect: (Int) -> Unit,
+    icons: List<CategoryIcon>,
+    selectedIconId: Long?,
+    onSelect: (Long) -> Unit,
 ) {
+    val totalCount = icons.size
     val rowCount = (totalCount + ICON_GRID_COLUMNS - 1) / ICON_GRID_COLUMNS
     Column(verticalArrangement = Arrangement.spacedBy(ICON_GRID_ROW_GAP)) {
         repeat(rowCount) { rowIndex ->
@@ -52,9 +54,10 @@ private fun IconGrid(
                 repeat(ICON_GRID_COLUMNS) { columnIndex ->
                     val itemIndex = rowIndex * ICON_GRID_COLUMNS + columnIndex
                     if (itemIndex < totalCount) {
+                        val icon = icons[itemIndex]
                         IconCircle(
-                            selected = itemIndex == selectedIndex,
-                            onClick = { onSelect(itemIndex) },
+                            selected = icon.id == selectedIconId,
+                            onClick = { onSelect(icon.id) },
                         )
                     } else {
                         Spacer(modifier = Modifier.size(ICON_CIRCLE_SIZE))
@@ -81,7 +84,6 @@ private fun IconCircle(
         } else {
             Modifier
         }
-    // 추후 GET /categories/icons 연동 시 Image / AsyncImage 추가.
     Box(
         modifier =
             Modifier

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterIconGrid.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterIconGrid.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -15,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
 import com.obrit.obrit.shared.model.categories.CategoryIcon
@@ -56,6 +58,7 @@ private fun IconGrid(
                     if (itemIndex < totalCount) {
                         val icon = icons[itemIndex]
                         IconCircle(
+                            url = icon.url,
                             selected = icon.id == selectedIconId,
                             onClick = { onSelect(icon.id) },
                         )
@@ -70,6 +73,7 @@ private fun IconGrid(
 
 @Composable
 private fun IconCircle(
+    url: String,
     selected: Boolean,
     onClick: () -> Unit,
 ) {
@@ -92,7 +96,13 @@ private fun IconCircle(
                 .background(colors.gray750)
                 .then(borderModifier)
                 .clickable(onClick = onClick),
-    )
+    ) {
+        AsyncImage(
+            model = url,
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
 }
 
 private const val ICON_GRID_COLUMNS = 5

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterScreen.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.obrit.feature.register.viewmodel.DirectRegisterSideEffect
 import com.obrit.feature.register.viewmodel.DirectRegisterViewModel
+import com.obrit.obrit.shared.model.categories.Category
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -12,7 +13,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun DirectRegisterScreen(
     onBack: () -> Unit,
-    onRegister: (name: String, selectedIconIndex: Int?) -> Unit,
+    onRegister: (Category) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DirectRegisterViewModel = koinViewModel(),
 ) {
@@ -32,8 +33,7 @@ fun DirectRegisterScreen(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is DirectRegisterSideEffect.OnRegistered ->
-                onRegister(sideEffect.name, sideEffect.selectedIconIndex)
+            is DirectRegisterSideEffect.OnRegistered -> onRegister(sideEffect.category)
             is DirectRegisterSideEffect.OnBack -> onBack()
         }
     }
@@ -41,7 +41,7 @@ fun DirectRegisterScreen(
 
 internal data class DirectRegisterScreenAction(
     val onNameChange: (String) -> Unit,
-    val onIconSelect: (Int) -> Unit,
+    val onIconSelect: (Long) -> Unit,
     val onSubmit: () -> Unit,
     val onBack: () -> Unit,
 )

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterScreenContent.kt
@@ -41,7 +41,6 @@ import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
 import com.obrit.android.core.designsystem.theme.OBRitTheme
 import com.obrit.feature.register.screen.common.FieldSectionHeader
 import com.obrit.feature.register.screen.common.rememberFocusBringIntoView
-import com.obrit.feature.register.viewmodel.DIRECT_REGISTER_ICON_PLACEHOLDER_COUNT
 import com.obrit.feature.register.viewmodel.DIRECT_REGISTER_NAME_MAX_LENGTH
 import com.obrit.feature.register.viewmodel.DirectRegisterUiState
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
@@ -76,7 +75,7 @@ internal fun DirectRegisterScreenContent(
 private fun DirectRegisterBody(
     state: DirectRegisterUiState,
     onNameChange: (String) -> Unit,
-    onIconSelect: (Int) -> Unit,
+    onIconSelect: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val colors = LocalOBRitColor.current
@@ -121,7 +120,7 @@ private fun DirectRegisterTitleSection() {
 private fun DirectRegisterFieldsColumn(
     state: DirectRegisterUiState,
     onNameChange: (String) -> Unit,
-    onIconSelect: (Int) -> Unit,
+    onIconSelect: (Long) -> Unit,
 ) {
     Column(
         modifier =
@@ -133,8 +132,8 @@ private fun DirectRegisterFieldsColumn(
         NameField(value = state.name, onValueChange = onNameChange)
         IconGridField(
             label = DIRECT_REGISTER_ICON_LABEL,
-            totalCount = DIRECT_REGISTER_ICON_PLACEHOLDER_COUNT,
-            selectedIndex = state.selectedIconIndex,
+            icons = state.icons,
+            selectedIconId = state.selectedIconId,
             onSelect = onIconSelect,
             headerSlot = { FieldSectionHeader(label = it) },
         )
@@ -240,23 +239,6 @@ private fun DirectRegisterScreenEmptyPreview() {
     OBRitTheme(dynamicColor = false) {
         DirectRegisterScreenContent(
             state = DirectRegisterUiState(),
-            action =
-                DirectRegisterScreenAction(
-                    onNameChange = {},
-                    onIconSelect = {},
-                    onSubmit = {},
-                    onBack = {},
-                ),
-        )
-    }
-}
-
-@Preview(name = "DirectRegisterScreen Filled", showBackground = false)
-@Composable
-private fun DirectRegisterScreenFilledPreview() {
-    OBRitTheme(dynamicColor = false) {
-        DirectRegisterScreenContent(
-            state = DirectRegisterUiState(name = "화장품 퍼프", selectedIconIndex = 0),
             action =
                 DirectRegisterScreenAction(
                     onNameChange = {},

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterFields.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterFields.kt
@@ -185,6 +185,7 @@ private class LastReplaceDateMenuPositionProvider(
 @Composable
 internal fun QuantityField(
     title: String,
+    iconUrl: String,
     quantity: Int,
     totalCount: Int,
     onQuantityChange: (Int) -> Unit,
@@ -193,6 +194,7 @@ internal fun QuantityField(
         FieldSectionHeader(label = MANUAL_REGISTER_QUANTITY_LABEL)
         QuantityCard(
             title = title.ifEmpty { MANUAL_REGISTER_QUANTITY_TITLE_PLACEHOLDER },
+            iconUrl = iconUrl,
             totalCount = totalCount,
             quantity = quantity,
             onQuantityChange = onQuantityChange,

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterFields.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterFields.kt
@@ -51,6 +51,7 @@ import com.obrit.feature.register.screen.common.FieldSectionHeader
 import com.obrit.feature.register.screen.common.rememberFocusBringIntoView
 import com.obrit.obrit.shared.designsystem.tokens.atom.radius.AtomRadius
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
+import com.obrit.obrit.shared.model.items.ReplacementPeriod
 
 @Composable
 internal fun CategoryField(
@@ -103,17 +104,18 @@ internal fun NameField(
 
 @Composable
 internal fun LastReplaceDateField(
-    selectedOption: String,
-    onOptionChange: (String) -> Unit,
+    selected: ReplacementPeriod?,
+    onChange: (ReplacementPeriod?) -> Unit,
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
     var triggerSize by remember { mutableStateOf(IntSize.Zero) }
+    val displayLabel = selected?.let { period -> LAST_REPLACE_DATE_OPTIONS.first { it.second == period }.first }.orEmpty()
 
     Column(verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp)) {
         FieldSectionHeader(label = MANUAL_REGISTER_LAST_REPLACE_DATE_LABEL)
         Box {
             OBRitDropdown(
-                value = selectedOption,
+                value = displayLabel,
                 onClick = { expanded = !expanded },
                 placeholder = MANUAL_REGISTER_LAST_REPLACE_DATE_PLACEHOLDER,
                 expanded = expanded,
@@ -124,11 +126,11 @@ internal fun LastReplaceDateField(
             )
             if (expanded) {
                 LastReplaceDateMenu(
-                    selectedOption = selectedOption,
+                    selected = selected,
                     triggerWidthPx = triggerSize.width,
                     onDismiss = { expanded = false },
                     onItemSelect = {
-                        onOptionChange(it)
+                        onChange(it)
                         expanded = false
                     },
                 )
@@ -139,10 +141,10 @@ internal fun LastReplaceDateField(
 
 @Composable
 private fun LastReplaceDateMenu(
-    selectedOption: String,
+    selected: ReplacementPeriod?,
     triggerWidthPx: Int,
     onDismiss: () -> Unit,
-    onItemSelect: (String) -> Unit,
+    onItemSelect: (ReplacementPeriod) -> Unit,
 ) {
     val density = LocalDensity.current
     val menuGapPx = with(density) { LAST_REPLACE_DATE_MENU_GAP.roundToPx() }
@@ -154,9 +156,9 @@ private fun LastReplaceDateMenu(
         properties = PopupProperties(focusable = true),
     ) {
         OBRitDropdownMenu(
-            items = LAST_REPLACE_DATE_OPTIONS,
-            selectedIndex = LAST_REPLACE_DATE_OPTIONS.indexOf(selectedOption).takeIf { it >= 0 },
-            onItemClick = { index -> onItemSelect(LAST_REPLACE_DATE_OPTIONS[index]) },
+            items = LAST_REPLACE_DATE_OPTIONS.map { it.first },
+            selectedIndex = LAST_REPLACE_DATE_OPTIONS.indexOfFirst { it.second == selected }.takeIf { it >= 0 },
+            onItemClick = { index -> onItemSelect(LAST_REPLACE_DATE_OPTIONS[index].second) },
             modifier = with(density) { Modifier.width(triggerWidthPx.toDp()) },
         )
     }
@@ -286,8 +288,8 @@ private val LAST_REPLACE_DATE_MENU_GAP = 6.dp
 
 private val LAST_REPLACE_DATE_OPTIONS =
     listOf(
-        "1주일 이내",
-        "2-4주 전",
-        "1-3개월 전",
-        "3개월 이전",
+        "1주일 이내" to ReplacementPeriod.WITHIN_WEEK,
+        "2-4주 전" to ReplacementPeriod.WITHIN_MONTH,
+        "1-3개월 전" to ReplacementPeriod.WITHIN_THREE_MONTHS,
+        "3개월 이전" to ReplacementPeriod.OVER_THREE_MONTHS,
     )

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterQuantityCard.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterQuantityCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.obrit.android.core.designsystem.component.stepper.OBRitStepper
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
 import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
@@ -26,6 +28,7 @@ import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
 @Composable
 internal fun QuantityCard(
     title: String,
+    iconUrl: String,
     totalCount: Int,
     quantity: Int,
     onQuantityChange: (Int) -> Unit,
@@ -47,7 +50,13 @@ internal fun QuantityCard(
                     .size(QUANTITY_CARD_IMAGE_SIZE)
                     .clip(CircleShape)
                     .background(colors.gray750),
-        )
+        ) {
+            AsyncImage(
+                model = iconUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
         QuantityCardText(title = title, totalCount = totalCount, modifier = Modifier.weight(1f))
         OBRitStepper(value = quantity, onValueChange = onQuantityChange)
     }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreen.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.obrit.feature.register.viewmodel.ManualRegisterSideEffect
 import com.obrit.feature.register.viewmodel.ManualRegisterViewModel
+import com.obrit.obrit.shared.model.categories.Category
+import com.obrit.obrit.shared.model.items.ReplacementPeriod
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -19,23 +21,21 @@ fun ManualRegisterScreen(
 ) {
     val state by viewModel.collectAsState()
 
-    LaunchedEffect(pendingCategory?.name) {
+    LaunchedEffect(pendingCategory?.category?.id) {
         val handle = pendingCategory ?: return@LaunchedEffect
-        val name = handle.name
-        if (!name.isNullOrBlank()) {
-            viewModel.onCategoryChange(name)
-            handle.onConsumed()
-        }
+        val category = handle.category ?: return@LaunchedEffect
+        viewModel.applyPendingCategory(category)
+        handle.onConsumed()
     }
 
     ManualRegisterScreenContent(
         state = state,
         action =
             ManualRegisterScreenAction(
-                onCategoryChange = viewModel::onCategoryChange,
+                onCategoryConfirm = viewModel::onCategorySelect,
                 onNameChange = viewModel::onNameChange,
                 onQuantityChange = viewModel::onQuantityChange,
-                onLastReplaceDateChange = viewModel::onLastReplaceDateChange,
+                onLastReplacementPeriodChange = viewModel::onLastReplacementPeriodChange,
                 onSubmit = viewModel::onSubmit,
                 onBack = viewModel::onBack,
                 onDirectRegister = viewModel::onDirectRegister,
@@ -59,15 +59,15 @@ data class ManualRegisterNavigation(
 )
 
 data class PendingCategory(
-    val name: String?,
+    val category: Category?,
     val onConsumed: () -> Unit,
 )
 
 internal data class ManualRegisterScreenAction(
-    val onCategoryChange: (String) -> Unit,
+    val onCategoryConfirm: (Category) -> Unit,
     val onNameChange: (String) -> Unit,
     val onQuantityChange: (Int) -> Unit,
-    val onLastReplaceDateChange: (String) -> Unit,
+    val onLastReplacementPeriodChange: (ReplacementPeriod?) -> Unit,
     val onSubmit: () -> Unit,
     val onBack: () -> Unit,
     val onDirectRegister: () -> Unit,

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
@@ -41,6 +41,8 @@ import com.obrit.android.core.designsystem.theme.OBRitTheme
 import com.obrit.feature.register.screen.category.CategorySelectionBottomSheet
 import com.obrit.feature.register.viewmodel.ManualRegisterUiState
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
+import com.obrit.obrit.shared.model.categories.Category
+import com.obrit.obrit.shared.model.items.ReplacementPeriod
 
 @Composable
 internal fun ManualRegisterScreenContent(
@@ -65,7 +67,7 @@ internal fun ManualRegisterScreenContent(
             fieldActions =
                 ManualRegisterFieldActions(
                     onNameChange = action.onNameChange,
-                    onLastReplaceDateChange = action.onLastReplaceDateChange,
+                    onLastReplacementPeriodChange = action.onLastReplacementPeriodChange,
                     onCategoryClick = { isCategorySheetOpen = true },
                 ),
             onQuantityChange = action.onQuantityChange,
@@ -76,8 +78,9 @@ internal fun ManualRegisterScreenContent(
 
     ManualRegisterCategorySheetHost(
         visible = isCategorySheetOpen,
-        initialSelected = state.categoryName,
-        onConfirm = action.onCategoryChange,
+        categories = state.categories,
+        initialSelectedId = state.selectedCategoryId,
+        onConfirm = action.onCategoryConfirm,
         onDismiss = { isCategorySheetOpen = false },
         onDirectRegister = action.onDirectRegister,
     )
@@ -86,16 +89,18 @@ internal fun ManualRegisterScreenContent(
 @Composable
 private fun ManualRegisterCategorySheetHost(
     visible: Boolean,
-    initialSelected: String,
-    onConfirm: (String) -> Unit,
+    categories: List<Category>,
+    initialSelectedId: Long?,
+    onConfirm: (Category) -> Unit,
     onDismiss: () -> Unit,
     onDirectRegister: () -> Unit,
 ) {
     if (!visible) return
     CategorySelectionBottomSheet(
-        initialSelected = initialSelected,
-        onConfirm = { name ->
-            onConfirm(name)
+        categories = categories,
+        initialSelectedId = initialSelectedId,
+        onConfirm = { category ->
+            onConfirm(category)
             onDismiss()
         },
         onDismissRequest = onDismiss,
@@ -109,7 +114,7 @@ private fun ManualRegisterCategorySheetHost(
 
 internal data class ManualRegisterFieldActions(
     val onNameChange: (String) -> Unit,
-    val onLastReplaceDateChange: (String) -> Unit,
+    val onLastReplacementPeriodChange: (ReplacementPeriod?) -> Unit,
     val onCategoryClick: () -> Unit,
 )
 
@@ -174,8 +179,8 @@ private fun ManualRegisterFields(
         CategoryField(value = state.categoryName, onClick = fieldActions.onCategoryClick)
         NameField(value = state.name, onValueChange = fieldActions.onNameChange)
         LastReplaceDateField(
-            selectedOption = state.lastReplaceDate,
-            onOptionChange = fieldActions.onLastReplaceDateChange,
+            selected = state.lastReplacementPeriod,
+            onChange = fieldActions.onLastReplacementPeriodChange,
         )
         QuantityField(
             title = state.categoryName,
@@ -267,10 +272,10 @@ private fun ManualRegisterScreenFilledPreview() {
 
 private fun previewAction(): ManualRegisterScreenAction =
     ManualRegisterScreenAction(
-        onCategoryChange = {},
+        onCategoryConfirm = {},
         onNameChange = {},
         onQuantityChange = {},
-        onLastReplaceDateChange = {},
+        onLastReplacementPeriodChange = {},
         onSubmit = {},
         onBack = {},
         onDirectRegister = {},

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
@@ -39,6 +39,7 @@ import com.obrit.android.core.designsystem.theme.LocalOBRitColor
 import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
 import com.obrit.android.core.designsystem.theme.OBRitTheme
 import com.obrit.feature.register.screen.category.CategorySelectionBottomSheet
+import com.obrit.feature.register.screen.category.CategorySheetActions
 import com.obrit.feature.register.viewmodel.ManualRegisterUiState
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
 import com.obrit.obrit.shared.model.categories.Category
@@ -80,9 +81,12 @@ internal fun ManualRegisterScreenContent(
         visible = isCategorySheetOpen,
         categories = state.categories,
         initialSelectedId = state.selectedCategoryId,
-        onConfirm = action.onCategoryConfirm,
-        onDismiss = { isCategorySheetOpen = false },
-        onDirectRegister = action.onDirectRegister,
+        actions =
+            CategorySheetActions(
+                onConfirm = action.onCategoryConfirm,
+                onDismiss = { isCategorySheetOpen = false },
+                onDirectRegister = action.onDirectRegister,
+            ),
     )
 }
 
@@ -91,24 +95,25 @@ private fun ManualRegisterCategorySheetHost(
     visible: Boolean,
     categories: List<Category>,
     initialSelectedId: Long?,
-    onConfirm: (Category) -> Unit,
-    onDismiss: () -> Unit,
-    onDirectRegister: () -> Unit,
+    actions: CategorySheetActions,
 ) {
     if (!visible) return
     CategorySelectionBottomSheet(
         categories = categories,
         initialSelectedId = initialSelectedId,
-        onConfirm = { category ->
-            onConfirm(category)
-            onDismiss()
-        },
-        onDismissRequest = onDismiss,
-        onDirectRegisterClick = {
-            // 시트를 먼저 닫아야 Dialog가 새 화면을 가리지 않는다.
-            onDismiss()
-            onDirectRegister()
-        },
+        actions =
+            CategorySheetActions(
+                onConfirm = { category ->
+                    actions.onConfirm(category)
+                    actions.onDismiss()
+                },
+                onDismiss = actions.onDismiss,
+                // 시트를 먼저 닫아야 Dialog가 새 화면을 가리지 않는다.
+                onDirectRegister = {
+                    actions.onDismiss()
+                    actions.onDirectRegister()
+                },
+            ),
     )
 }
 

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
@@ -184,6 +184,7 @@ private fun ManualRegisterFields(
         )
         QuantityField(
             title = state.categoryName,
+            iconUrl = state.categoryIconUrl,
             quantity = state.quantity,
             totalCount = state.totalCount,
             onQuantityChange = onQuantityChange,

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/DirectRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/DirectRegisterViewModel.kt
@@ -2,36 +2,53 @@ package com.obrit.feature.register.viewmodel
 
 import androidx.compose.runtime.Immutable
 import com.obrit.android.core.ui.BaseContainerHost
+import com.obrit.obrit.shared.data.repository.CategoryRepository
+import com.obrit.obrit.shared.model.categories.Category
+import com.obrit.obrit.shared.model.categories.CategoryIcon
 import org.orbitmvi.orbit.viewmodel.container
 
-class DirectRegisterViewModel : BaseContainerHost<DirectRegisterUiState, DirectRegisterSideEffect>() {
+class DirectRegisterViewModel(
+    private val categoryRepository: CategoryRepository,
+) : BaseContainerHost<DirectRegisterUiState, DirectRegisterSideEffect>() {
     override val container =
         container<DirectRegisterUiState, DirectRegisterSideEffect>(
             DirectRegisterUiState(),
-        )
+        ) {
+            loadIcons()
+        }
+
+    private fun loadIcons() =
+        intent {
+            categoryRepository.getCategoryIcons()
+                .onSuccess { icons ->
+                    reduce { state.copy(icons = icons) }
+                }
+        }
 
     fun onNameChange(value: String) =
         intent {
-            reduce {
-                state.copy(name = value)
-            }
+            reduce { state.copy(name = value) }
         }
 
-    fun onIconSelect(index: Int) =
+    fun onIconSelect(iconId: Long) =
         intent {
-            reduce {
-                state.copy(selectedIconIndex = index)
-            }
+            reduce { state.copy(selectedIconId = iconId) }
         }
 
     fun onSubmit() =
         intent {
-            postSideEffect(
-                DirectRegisterSideEffect.OnRegistered(
-                    name = state.name,
-                    selectedIconIndex = state.selectedIconIndex,
-                ),
-            )
+            val current = state
+            val iconId = current.selectedIconId ?: return@intent
+            if (current.isSubmitting) return@intent
+            reduce { state.copy(isSubmitting = true) }
+            categoryRepository.createCategory(name = current.name, iconId = iconId)
+                .onSuccess { category ->
+                    reduce { state.copy(isSubmitting = false) }
+                    postSideEffect(DirectRegisterSideEffect.OnRegistered(category))
+                }
+                .onFailure {
+                    reduce { state.copy(isSubmitting = false) }
+                }
         }
 
     fun onBack() =
@@ -42,27 +59,23 @@ class DirectRegisterViewModel : BaseContainerHost<DirectRegisterUiState, DirectR
 
 @Immutable
 data class DirectRegisterUiState(
+    val icons: List<CategoryIcon> = emptyList(),
     val name: String = "",
-    // 추후 GET /categories/icons 연동 시 selectedIconId: String? 으로 교체
-    val selectedIconIndex: Int? = null,
+    val selectedIconId: Long? = null,
+    val isSubmitting: Boolean = false,
 ) {
     val isSubmitEnabled: Boolean
         get() =
             name.isNotBlank() &&
                 name.length <= DIRECT_REGISTER_NAME_MAX_LENGTH &&
-                selectedIconIndex != null
+                selectedIconId != null &&
+                !isSubmitting
 }
 
 sealed interface DirectRegisterSideEffect {
-    data class OnRegistered(
-        val name: String,
-        val selectedIconIndex: Int?,
-    ) : DirectRegisterSideEffect
+    data class OnRegistered(val category: Category) : DirectRegisterSideEffect
 
     data object OnBack : DirectRegisterSideEffect
 }
 
 internal const val DIRECT_REGISTER_NAME_MAX_LENGTH = 15
-
-// 추후 GET /categories/icons 응답으로 교체. 일단 placeholder 41개 (5x8 + 1).
-internal const val DIRECT_REGISTER_ICON_PLACEHOLDER_COUNT = 41

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/DirectRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/DirectRegisterViewModel.kt
@@ -19,7 +19,8 @@ class DirectRegisterViewModel(
 
     private fun loadIcons() =
         intent {
-            categoryRepository.getCategoryIcons()
+            categoryRepository
+                .getCategoryIcons()
                 .onSuccess { icons ->
                     reduce { state.copy(icons = icons) }
                 }
@@ -41,12 +42,12 @@ class DirectRegisterViewModel(
             val iconId = current.selectedIconId ?: return@intent
             if (current.isSubmitting) return@intent
             reduce { state.copy(isSubmitting = true) }
-            categoryRepository.createCategory(name = current.name, iconId = iconId)
+            categoryRepository
+                .createCategory(name = current.name, iconId = iconId)
                 .onSuccess { category ->
                     reduce { state.copy(isSubmitting = false) }
                     postSideEffect(DirectRegisterSideEffect.OnRegistered(category))
-                }
-                .onFailure {
+                }.onFailure {
                     reduce { state.copy(isSubmitting = false) }
                 }
         }
@@ -73,7 +74,9 @@ data class DirectRegisterUiState(
 }
 
 sealed interface DirectRegisterSideEffect {
-    data class OnRegistered(val category: Category) : DirectRegisterSideEffect
+    data class OnRegistered(
+        val category: Category,
+    ) : DirectRegisterSideEffect
 
     data object OnBack : DirectRegisterSideEffect
 }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
@@ -83,6 +83,7 @@ class ManualRegisterViewModel(
                 .onSuccess {
                     reduce { ManualRegisterUiState(categories = state.categories) }
                     postSideEffect(ManualRegisterSideEffect.OnRegistered)
+                    loadCategories()
                 }
                 .onFailure {
                     reduce { state.copy(isSubmitting = false) }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
@@ -2,46 +2,91 @@ package com.obrit.feature.register.viewmodel
 
 import androidx.compose.runtime.Immutable
 import com.obrit.android.core.ui.BaseContainerHost
+import com.obrit.obrit.shared.data.repository.CategoryRepository
+import com.obrit.obrit.shared.data.repository.ItemRepository
+import com.obrit.obrit.shared.model.categories.Category
+import com.obrit.obrit.shared.model.items.CreateItemParams
+import com.obrit.obrit.shared.model.items.ReplacementPeriod
 import org.orbitmvi.orbit.viewmodel.container
 
-class ManualRegisterViewModel : BaseContainerHost<ManualRegisterUiState, ManualRegisterSideEffect>() {
+class ManualRegisterViewModel(
+    private val categoryRepository: CategoryRepository,
+    private val itemRepository: ItemRepository,
+) : BaseContainerHost<ManualRegisterUiState, ManualRegisterSideEffect>() {
     override val container =
         container<ManualRegisterUiState, ManualRegisterSideEffect>(
             ManualRegisterUiState(),
-        )
+        ) {
+            loadCategories()
+        }
 
-    fun onCategoryChange(value: String) =
+    private fun loadCategories() =
+        intent {
+            categoryRepository.getCategories()
+                .onSuccess { categories ->
+                    reduce { state.copy(categories = categories) }
+                }
+        }
+
+    fun onCategorySelect(category: Category) =
         intent {
             reduce {
-                state.copy(categoryName = value)
+                state.copy(
+                    selectedCategoryId = category.id,
+                    categoryName = category.name,
+                    existingCount = category.totalSpareQuantity,
+                )
             }
         }
 
     fun onNameChange(value: String) =
         intent {
-            reduce {
-                state.copy(name = value)
-            }
+            reduce { state.copy(name = value) }
         }
 
     fun onQuantityChange(value: Int) =
         intent {
-            reduce {
-                state.copy(quantity = value)
-            }
+            reduce { state.copy(quantity = value) }
         }
 
-    fun onLastReplaceDateChange(value: String) =
+    fun onLastReplacementPeriodChange(value: ReplacementPeriod?) =
+        intent {
+            reduce { state.copy(lastReplacementPeriod = value) }
+        }
+
+    fun applyPendingCategory(category: Category) =
         intent {
             reduce {
-                state.copy(lastReplaceDate = value)
+                state.copy(
+                    categories = state.categories + category,
+                    selectedCategoryId = category.id,
+                    categoryName = category.name,
+                    existingCount = category.totalSpareQuantity,
+                )
             }
         }
 
     fun onSubmit() =
         intent {
-            reduce { ManualRegisterUiState() }
-            postSideEffect(ManualRegisterSideEffect.OnRegistered)
+            val current = state
+            val categoryId = current.selectedCategoryId ?: return@intent
+            if (current.isSubmitting) return@intent
+            reduce { state.copy(isSubmitting = true) }
+            val params =
+                CreateItemParams(
+                    categoryId = categoryId,
+                    name = current.name,
+                    spareQuantity = current.quantity,
+                    lastReplacementPeriod = current.lastReplacementPeriod,
+                )
+            itemRepository.createItem(params)
+                .onSuccess {
+                    reduce { ManualRegisterUiState(categories = state.categories) }
+                    postSideEffect(ManualRegisterSideEffect.OnRegistered)
+                }
+                .onFailure {
+                    reduce { state.copy(isSubmitting = false) }
+                }
         }
 
     fun onBack() =
@@ -57,17 +102,25 @@ class ManualRegisterViewModel : BaseContainerHost<ManualRegisterUiState, ManualR
 
 @Immutable
 data class ManualRegisterUiState(
+    val categories: List<Category> = emptyList(),
+    val selectedCategoryId: Long? = null,
     val categoryName: String = "",
     val name: String = "",
     val quantity: Int = 0,
     val existingCount: Int = 0,
-    val lastReplaceDate: String = "",
+    val lastReplacementPeriod: ReplacementPeriod? = null,
+    val isSubmitting: Boolean = false,
 ) {
     val totalCount: Int
         get() = existingCount + quantity
 
     val isSubmitEnabled: Boolean
-        get() = categoryName.isNotBlank() && name.isNotBlank() && lastReplaceDate.isNotBlank() && quantity > 0
+        get() =
+            selectedCategoryId != null &&
+                name.isNotBlank() &&
+                lastReplacementPeriod != null &&
+                quantity > 0 &&
+                !isSubmitting
 }
 
 sealed interface ManualRegisterSideEffect {

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
@@ -22,7 +22,8 @@ class ManualRegisterViewModel(
 
     private fun loadCategories() =
         intent {
-            categoryRepository.getCategories()
+            categoryRepository
+                .getCategories()
                 .onSuccess { categories ->
                     reduce { state.copy(categories = categories) }
                 }
@@ -81,13 +82,13 @@ class ManualRegisterViewModel(
                     spareQuantity = current.quantity,
                     lastReplacementPeriod = current.lastReplacementPeriod,
                 )
-            itemRepository.createItem(params)
+            itemRepository
+                .createItem(params)
                 .onSuccess {
                     reduce { ManualRegisterUiState(categories = state.categories) }
                     postSideEffect(ManualRegisterSideEffect.OnRegistered)
                     loadCategories()
-                }
-                .onFailure {
+                }.onFailure {
                     reduce { state.copy(isSubmitting = false) }
                 }
         }

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
@@ -34,6 +34,7 @@ class ManualRegisterViewModel(
                 state.copy(
                     selectedCategoryId = category.id,
                     categoryName = category.name,
+                    categoryIconUrl = category.iconUrl,
                     existingCount = category.totalSpareQuantity,
                 )
             }
@@ -61,6 +62,7 @@ class ManualRegisterViewModel(
                     categories = state.categories + category,
                     selectedCategoryId = category.id,
                     categoryName = category.name,
+                    categoryIconUrl = category.iconUrl,
                     existingCount = category.totalSpareQuantity,
                 )
             }
@@ -106,6 +108,7 @@ data class ManualRegisterUiState(
     val categories: List<Category> = emptyList(),
     val selectedCategoryId: Long? = null,
     val categoryName: String = "",
+    val categoryIconUrl: String = "",
     val name: String = "",
     val quantity: Int = 0,
     val existingCount: Int = 0,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ orbit = "11.0.0"
 nav3Core = "1.1.1"
 lifecycleViewmodelNav3 = "2.10.0"
 kotlinxSerializationCore = "1.11.0"
+coil = "3.4.0"
 
 [libraries]
 
@@ -94,6 +95,11 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin" }
 orbit-core = { module = "org.orbit-mvi:orbit-core", version.ref = "orbit" }
 orbit-viewmodel = { module = "org.orbit-mvi:orbit-viewmodel", version.ref = "orbit" }
 orbit-compose = { module = "org.orbit-mvi:orbit-compose", version.ref = "orbit" }
+# endregion
+
+# region Coil
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 # endregion
 
 [plugins]

--- a/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/ItemRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/ItemRepositoryImpl.kt
@@ -104,7 +104,7 @@ private fun CreateItemParams.toCreateItemRequest() =
     CreateItemRequest(
         categoryId = categoryId,
         name = name,
-        count = count,
-        lastReplacedDate = lastReplacedDate?.value,
+        spareQuantity = spareQuantity,
+        lastReplacementPeriod = lastReplacementPeriod?.name,
         replacementIntervalDays = replacementIntervalDays,
     )

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/categories/Category.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/categories/Category.kt
@@ -4,7 +4,6 @@ data class Category(
     val id: Long,
     val name: String,
     val iconUrl: String,
-    val userId: Long?,
-    val createdAt: String?,
-    val defaultReplacementIntervalDays: Int,
+    val itemCount: Int,
+    val totalSpareQuantity: Int,
 )

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/items/CreateItemParams.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/items/CreateItemParams.kt
@@ -1,11 +1,9 @@
 package com.obrit.obrit.shared.model.items
 
-import com.obrit.obrit.shared.model.ReplacementDate
-
 data class CreateItemParams(
     val categoryId: Long,
     val name: String,
-    val count: Int? = null,
-    val lastReplacedDate: ReplacementDate? = null,
+    val spareQuantity: Int? = null,
+    val lastReplacementPeriod: ReplacementPeriod? = null,
     val replacementIntervalDays: Int? = null,
 )

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/items/ReplacementPeriod.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/items/ReplacementPeriod.kt
@@ -1,0 +1,8 @@
+package com.obrit.obrit.shared.model.items
+
+enum class ReplacementPeriod {
+    WITHIN_WEEK,
+    WITHIN_MONTH,
+    WITHIN_THREE_MONTHS,
+    OVER_THREE_MONTHS,
+}

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/request/item/CreateItemRequest.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/request/item/CreateItemRequest.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class CreateItemRequest(
     @SerialName("categoryId") val categoryId: Long,
     @SerialName("name") val name: String,
-    @SerialName("count") val count: Int? = null,
-    @SerialName("lastReplacedDate") val lastReplacedDate: String? = null,
+    @SerialName("spareQuantity") val spareQuantity: Int? = null,
+    @SerialName("lastReplacementPeriod") val lastReplacementPeriod: String? = null,
     @SerialName("replacementIntervalDays") val replacementIntervalDays: Int? = null,
 )

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/category/CategoryIconResponse.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/category/CategoryIconResponse.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CategoryIconResponse(
-    @SerialName("id") val id: Long,
+    @SerialName("iconId") val id: Long,
     @SerialName("url") val url: String,
 )
 

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/category/CategoryResponse.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/category/CategoryResponse.kt
@@ -6,12 +6,11 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CategoryResponse(
-    @SerialName("id") val id: Long,
+    @SerialName("categoryId") val id: Long,
     @SerialName("name") val name: String,
     @SerialName("iconUrl") val iconUrl: String,
-    @SerialName("userId") val userId: Long? = null,
-    @SerialName("createdAt") val createdAt: String? = null,
-    @SerialName("defaultReplacementIntervalDays") val defaultReplacementIntervalDays: Int,
+    @SerialName("itemCount") val itemCount: Int,
+    @SerialName("totalSpareQuantity") val totalSpareQuantity: Int,
 )
 
 fun CategoryResponse.toCategory() =
@@ -19,7 +18,6 @@ fun CategoryResponse.toCategory() =
         id = id,
         name = name,
         iconUrl = iconUrl,
-        userId = userId,
-        createdAt = createdAt,
-        defaultReplacementIntervalDays = defaultReplacementIntervalDays,
+        itemCount = itemCount,
+        totalSpareQuantity = totalSpareQuantity,
     )

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/item/ItemResponse.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/item/ItemResponse.kt
@@ -7,11 +7,11 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ItemResponse(
-    @SerialName("id") val id: Long,
+    @SerialName("itemId") val id: Long,
     @SerialName("categoryId") val categoryId: Long,
     @SerialName("categoryName") val categoryName: String,
     @SerialName("name") val name: String,
-    @SerialName("count") val count: Int,
+    @SerialName("spareQuantity") val count: Int,
     @SerialName("replacementIntervalDays") val replacementIntervalDays: Int,
     @SerialName("lastReplacedDate") val lastReplacedDate: String? = null,
     @SerialName("nextReplacementDate") val nextReplacementDate: String? = null,


### PR DESCRIPTION
### 작업 요약

- 소모품 수동 등록 화면의 4개 endpoint 연동 (GET/POST `/categories`, GET `/categories/icons`, POST `/items`)
- 변경된 swagger 스펙(필드명·enum·신규 필드) shared 레이어 반영
- 서버 제공 카테고리/아이콘 이미지를 Coil 3로 렌더링

### 관련 이슈

- close #120

### 변경 사항

**shared/network DTO**
- `CategoryResponse`: JSON key `id` → `categoryId`, 신규 필드 `itemCount`/`totalSpareQuantity` 추가, 미사용 필드(`userId`/`createdAt`/`defaultReplacementIntervalDays`) 제거
- `CategoryIconResponse`: `id` → `iconId`
- `ItemResponse`: `id` → `itemId`, `count` → `spareQuantity` (POST /items 응답 직렬화용)
- `CreateItemRequest`: `count` → `spareQuantity`, `lastReplacedDate(date)` → `lastReplacementPeriod(enum)`

**shared/model**
- `Category`: 미사용 필드 제거, `itemCount`/`totalSpareQuantity` 추가
- `ReplacementPeriod` enum 신규 (`WITHIN_WEEK`/`WITHIN_MONTH`/`WITHIN_THREE_MONTHS`/`OVER_THREE_MONTHS`)
- `CreateItemParams`: 도메인도 새 이름(`spareQuantity`, `lastReplacementPeriod`)으로 rename

**shared/data**
- `ItemRepositoryImpl.toCreateItemRequest()`: 신규 필드명·enum 매핑

**android UI (feature/register)**
- `ManualRegisterViewModel`: state에 `categoryIconUrl`/`lastReplacementPeriod` 추가, 카테고리 선택 시 `existingCount = totalSpareQuantity` 채움
- 등록 직후 `loadCategories()` 재호출로 itemCount/totalSpareQuantity 즉시 갱신
- "마지막 교체 일자" 드롭다운을 `List<Pair<String, ReplacementPeriod>>` 기반 enum 매핑으로 변경
- 카테고리 시트 row · 직접 등록 아이콘 그리드 · 등록 수량 카드 세 곳에 `AsyncImage`로 서버 URL 렌더링
- 카테고리 시트 콜백을 `CategorySheetActions`로 묶어 LongParameterList 위반 해소

**의존성**
- Coil `3.4.0` 도입 (`coil-compose`, `coil-network-okhttp`)

### 변경 이유

- 서버에서 4개 endpoint 응답 스키마 / POST body 가 변경되어 그에 맞춰야 수동 등록 end-to-end 흐름이 동작
- 카테고리·아이콘의 시각적 식별이 placeholder 박스로는 불가능하여 이미지 로딩 도입 필요

### 영향 범위

- [x] UI 변경
- [x] API 연동 변경
- [x] 공통 컴포넌트 변경 (shared 도메인 모델 / DTO)
- [x] 시스템 영향 가능 (`libs.versions.toml`, feature `build.gradle.kts`에 Coil 의존성 추가)

### 리뷰 요청 포인트

- `Category` 도메인의 기존 미사용 필드(`userId`/`createdAt`/`defaultReplacementIntervalDays`) 제거 — 코드 전체 grep 결과 사용처가 없어서 정리했는데 다른 모듈에서 곧 사용 예정이라면 알려주세요. `Json { ignoreUnknownKeys = true }`라 서버 응답에 남아있어도 파싱은 OK.
- `lastReplacedDate(date)`와 enum이 동시에 존재하는 상황을 분리하기 위해 응답 ISO date용 `ReplacementDate` value class는 유지하고 요청용 `ReplacementPeriod` enum을 신규 도입했습니다. (PATCH /items 등 본 PR 범위 외 endpoint는 손대지 않음)
- 등록 직후 카테고리 시트가 stale하게 보이는 이슈를 \`onSubmit().onSuccess\` 안에서 \`loadCategories()\` 재호출로 해결했습니다. 화면 진입 시 LaunchedEffect refetch 같은 다른 방식도 가능하니 의견 주세요.

### 테스트 / 검증

- [x] build 통과
- [x] ktlint 통과
- [x] detekt 통과
- [ ] unit test 통과
- [x] 수동 테스트 완료

수동 테스트 시나리오:
1. 홈 → 수동 등록 → 카테고리 시트 열림(`GET /categories`), 각 row에 `itemCount`와 아이콘 이미지 표시
2. 카테고리 선택 → 수량 카드 "전체 N개"가 `totalSpareQuantity + 입력 수량`으로 동작, 카드 아이콘 표시
3. 마지막 교체 일자 4개 선택지 선택 → CTA 활성화
4. 제출(`POST /items`) → 등록 완료 화면 진입 → 다시 등록 진입 시 itemCount 갱신 반영됨
5. 검색 결과 없음 → 직접 등록 진입 → 아이콘 그리드(`GET /categories/icons`) 표시, 아이콘 이미지 렌더링
6. 새 카테고리 입력 + 아이콘 선택 + 제출(`POST /categories`) → 카테고리 시트에 반영

### 스크린샷 / 영상

영상 크기가 너무 커서 첨부가 안되서.. 궁금하시면 갠톡 주세요

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#120-manual-register-api`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식
- [x] self-review 완료
- [ ] 문서 반영 필요 시 반영 완료