### PR TITLE
feat: Android 홈 API 연동 수정 (#131)

### DIFF
--- a/android/app/src/main/kotlin/com/obrit/obrit/navigation/HomeNavigation.kt
+++ b/android/app/src/main/kotlin/com/obrit/obrit/navigation/HomeNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.obrit.feature.detail.screen.DetailScreen
-import com.obrit.feature.home.screen.ConsumableListScreen
+import com.obrit.feature.home.screen.ItemListScreen
 import com.obrit.feature.home.screen.HomeScreen
 import com.obrit.obrit.navigation.route.HomeRoute
 
@@ -35,7 +35,7 @@ fun HomeNavigation(
                     )
                 }
                 entry<HomeRoute.ConsumableList> {
-                    ConsumableListScreen(
+                    ItemListScreen(
                         onBack = { homeBackStack.removeLastOrNull() },
                         onItemClick = { itemId -> homeBackStack.add(HomeRoute.Detail(itemId.toInt())) },
                         modifier = Modifier,

--- a/android/app/src/main/kotlin/com/obrit/obrit/navigation/HomeNavigation.kt
+++ b/android/app/src/main/kotlin/com/obrit/obrit/navigation/HomeNavigation.kt
@@ -6,8 +6,8 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.obrit.feature.detail.screen.DetailScreen
-import com.obrit.feature.home.screen.ItemListScreen
 import com.obrit.feature.home.screen.HomeScreen
+import com.obrit.feature.home.screen.ItemListScreen
 import com.obrit.obrit.navigation.route.HomeRoute
 
 @Composable

--- a/android/core/designsystem/src/main/java/com/obrit/android/core/designsystem/component/card/OBRitCard.kt
+++ b/android/core/designsystem/src/main/java/com/obrit/android/core/designsystem/component/card/OBRitCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
@@ -67,6 +68,8 @@ fun OBRitCardGrid(
                 text = title,
                 style = typography.xl.copy(fontWeight = FontWeight.Bold),
                 color = colors.common00,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             Row(
                 horizontalArrangement = Arrangement.spacedBy(AtomSpacing.S1.dp),
@@ -131,6 +134,8 @@ fun OBRitCardList(
                 text = title,
                 style = typography.xl.copy(fontWeight = FontWeight.Bold),
                 color = colors.common00,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             Row(
                 horizontalArrangement = Arrangement.spacedBy(AtomSpacing.S0_5.dp),

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreen.kt
@@ -1,8 +1,13 @@
 package com.obrit.feature.home.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.obrit.feature.home.viewmodel.ConsumableListSortOrder
 import com.obrit.feature.home.viewmodel.HomeSideEffect
 import com.obrit.feature.home.viewmodel.HomeViewModel
@@ -23,6 +28,7 @@ fun HomeScreen(
     viewModel: HomeViewModel = koinViewModel(),
 ) {
     val state by viewModel.collectAsState()
+    HomeResumeRefreshEffect(onResume = viewModel::onHomeResumed)
 
     HomeScreenContent(
         state = state,
@@ -49,6 +55,27 @@ fun HomeScreen(
             is HomeSideEffect.OnNotificationClick -> onNotificationClick()
             is HomeSideEffect.OnProfileClick -> onProfileClick()
             is HomeSideEffect.OnMoreClick -> onMoreClick()
+        }
+    }
+}
+
+@Composable
+private fun HomeResumeRefreshEffect(onResume: () -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnResume by rememberUpdatedState(onResume)
+
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    currentOnResume()
+                }
+            }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 }

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenFailureContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenFailureContent.kt
@@ -1,10 +1,55 @@
 package com.obrit.feature.home.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.obrit.android.core.designsystem.component.topbar.OBRitHomeTopBar
+import com.obrit.android.core.designsystem.theme.LocalOBRitColor
+import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
+import com.obrit.android.core.designsystem.theme.OBRitTheme
 
 @Composable
 internal fun HomeScreenFailureContent(modifier: Modifier = Modifier) {
-    Box(modifier = modifier)
+    val colors = LocalOBRitColor.current
+    val typography = LocalOBRitTypography.current
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(colors.gray900),
+    ) {
+        OBRitHomeTopBar(
+            onSearchClick = {},
+            onNotificationClick = {},
+            onProfileClick = {},
+            modifier = Modifier.statusBarsPadding(),
+        )
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "지금은 데이터를 불러올 수 없어요.\n다시 시도해주세요.",
+                textAlign = TextAlign.Center,
+                style = typography.base,
+                color = colors.common00,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF1D1B20)
+@Composable
+private fun HomeScreenFailureContentPreview() {
+    OBRitTheme {
+        HomeScreenFailureContent()
+    }
 }

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -44,6 +44,7 @@ import com.obrit.feature.home.screen.homeSection.MyStatusGraphSection
 import com.obrit.feature.home.screen.homeSection.QuickItemSection
 import com.obrit.feature.home.viewmodel.ConsumableListSortOrder
 import com.obrit.feature.home.viewmodel.HomeUiState
+import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
 
 @Suppress("LongMethod")
 @Composable
@@ -94,11 +95,8 @@ internal fun HomeScreenSuccessContent(
                             onLoadMoreItems = action.onLoadMoreItems,
                             onItemClick = action.onItemClick,
                         ),
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .navigationBarsPadding()
-                            .padding(bottom = 80.dp),
+                    modifier = Modifier.fillMaxSize(),
+                    contentBottomPadding = HomeGnbContentBottomPadding,
                 )
             }
         }
@@ -123,7 +121,11 @@ private fun HomeGnbBar(
             modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .padding(bottom = 24.dp, start = 24.dp, end = 24.dp),
+                .padding(
+                    start = HomeGnbHorizontalPadding,
+                    end = HomeGnbHorizontalPadding,
+                    bottom = HomeGnbBottomPadding,
+                ),
     ) {
         OBRitGnb(
             selectedTab = selectedTab,
@@ -240,5 +242,8 @@ private val HomeFabSize = 56.dp
 private val HomeFabIconSize = 30.dp
 private val HomeFabShadowBlur = 24.dp
 private val HomeFabShadowOffsetY = 16.dp
+private val HomeGnbHorizontalPadding = AtomSpacing.S5.dp
+private val HomeGnbBottomPadding = AtomSpacing.S5.dp
+private val HomeGnbContentBottomPadding = HomeFabSize + HomeGnbBottomPadding + AtomSpacing.S5.dp
 private const val HOME_FAB_SHADOW_ALPHA = 0.24f
 private const val ORBIT_ITEMS_SIZE = 10

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -15,12 +15,18 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -203,6 +209,18 @@ private fun HomeContents(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    coroutineScope.launch { scrollState.scrollTo(0) }
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     val currentOnLoadMoreItems by rememberUpdatedState(onLoadMoreItems)
     LaunchedEffect(scrollState.value) {
         if (scrollState.maxValue > 0 && scrollState.value >= scrollState.maxValue && state.items.hasNext) {

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -76,7 +76,7 @@ internal fun HomeScreenSuccessContent(
                     onItemClick = action.onItemClick,
                 )
             } else {
-                ConsumableListScreenContent(
+                ItemListScreenContent(
                     items = state.items.content,
                     hasNext = state.items.hasNext,
                     sortOrder = state.listSortOrder,
@@ -85,7 +85,7 @@ internal fun HomeScreenSuccessContent(
                     spareRange = state.spareRange,
                     spareFilterMax = state.spareFilterMax,
                     action =
-                        ConsumableListScreenAction(
+                        ItemListScreenAction(
                             onBack = {},
                             onSortOrderChange = action.onListSortOrderChange,
                             onDdayFilterChange = action.onDdayFilterChange,

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -1,5 +1,6 @@
 package com.obrit.feature.home.screen
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -23,10 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,6 +34,9 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.obrit.android.core.designsystem.R
 import com.obrit.android.core.designsystem.component.gnb.OBRitGnb
 import com.obrit.android.core.designsystem.component.gnb.OBRitGnbTab
@@ -51,6 +51,7 @@ import com.obrit.feature.home.screen.homeSection.QuickItemSection
 import com.obrit.feature.home.viewmodel.ConsumableListSortOrder
 import com.obrit.feature.home.viewmodel.HomeUiState
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
+import kotlinx.coroutines.launch
 
 @Suppress("LongMethod")
 @Composable
@@ -209,18 +210,7 @@ private fun HomeContents(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
-    val coroutineScope = rememberCoroutineScope()
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer =
-            LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_RESUME) {
-                    coroutineScope.launch { scrollState.scrollTo(0) }
-                }
-            }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
+    ScrollToTopOnResumeEffect(scrollState)
     val currentOnLoadMoreItems by rememberUpdatedState(onLoadMoreItems)
     LaunchedEffect(scrollState.value) {
         if (scrollState.maxValue > 0 && scrollState.value >= scrollState.maxValue && state.items.hasNext) {
@@ -252,7 +242,23 @@ private fun HomeContents(
             onMoreClick = onMoreClick,
             onItemClick = onItemClick,
         )
-        ItemUsageStatusSection(items = state.items.content, onItemClick = onItemClick)
+        ItemUsageStatusSection(items = state.usageItems, onItemClick = onItemClick)
+    }
+}
+
+@Composable
+private fun ScrollToTopOnResumeEffect(scrollState: ScrollState) {
+    val coroutineScope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    coroutineScope.launch { scrollState.scrollTo(0) }
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 }
 

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -216,10 +216,12 @@ private fun HomeContents(
                 .padding(bottom = 80.dp),
     ) {
         ItemStatusSection(overallStatus = state.overallStatus)
+        val totalCount = state.myStatusSummary.totalCount.coerceAtLeast(1)
+        val negativeRatio = state.myStatusSummary.needReplaceCount.toFloat() / totalCount
         ItemOrbitSection(
             items = state.items.content.take(ORBIT_ITEMS_SIZE),
-            normalRatio = state.status.ratio.goodPercentage / 100f,
-            warningRatio = state.status.ratio.warningPercentage / 100f,
+            normalRatio = 1f - negativeRatio,
+            negativeRatio = negativeRatio,
         )
         MyStatusGraphSection(myStatusSummary = state.myStatusSummary)
         QuickItemSection(buckets = state.buckets, onItemClick = onItemClick)

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/ItemListScreen.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/ItemListScreen.kt
@@ -9,7 +9,7 @@ import com.obrit.feature.home.viewmodel.HomeViewModel
 import org.koin.androidx.compose.koinViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 
-internal data class ConsumableListScreenAction(
+internal data class ItemListScreenAction(
     val onBack: () -> Unit,
     val onSortOrderChange: (ConsumableListSortOrder) -> Unit,
     val onDdayFilterChange: (Int) -> Unit,
@@ -20,7 +20,7 @@ internal data class ConsumableListScreenAction(
 )
 
 @Composable
-fun ConsumableListScreen(
+fun ItemListScreen(
     onBack: () -> Unit,
     onItemClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -29,7 +29,7 @@ fun ConsumableListScreen(
     val state by viewModel.collectAsState()
     val success = state as? HomeUiState.Success ?: return
 
-    ConsumableListScreenContent(
+    ItemListScreenContent(
         items = success.items.content,
         hasNext = success.items.hasNext,
         sortOrder = success.listSortOrder,
@@ -38,7 +38,7 @@ fun ConsumableListScreen(
         spareRange = success.spareRange,
         spareFilterMax = success.spareFilterMax,
         action =
-            ConsumableListScreenAction(
+            ItemListScreenAction(
                 onBack = onBack,
                 onSortOrderChange = viewModel::onListSortOrderChange,
                 onDdayFilterChange = viewModel::onDdayFilterChange,

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/ItemListScreenContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/ItemListScreenContent.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -75,6 +76,7 @@ internal fun ItemListScreenContent(
     spareFilterMax: Int,
     action: ItemListScreenAction,
     modifier: Modifier = Modifier,
+    contentBottomPadding: Dp = 0.dp,
 ) {
     var showFilterSheet by remember { mutableStateOf(false) }
     var showSortSheet by remember { mutableStateOf(false) }
@@ -99,7 +101,7 @@ internal fun ItemListScreenContent(
                     start = AtomSpacing.S5.dp,
                     end = AtomSpacing.S5.dp,
                     top = LIST_FILTER_BAR_HEIGHT.dp + AtomSpacing.S3.dp,
-                    bottom = AtomSpacing.S3.dp,
+                    bottom = AtomSpacing.S3.dp + contentBottomPadding,
                 ),
             verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
         ) {

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/ItemListScreenContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/ItemListScreenContent.kt
@@ -65,7 +65,7 @@ import kotlin.math.roundToInt
 
 @Suppress("LongMethod", "LongParameterList")
 @Composable
-internal fun ConsumableListScreenContent(
+internal fun ItemListScreenContent(
     items: List<HomeItemCard>,
     hasNext: Boolean,
     sortOrder: ConsumableListSortOrder,
@@ -73,20 +73,9 @@ internal fun ConsumableListScreenContent(
     ddayFilterMax: Int,
     spareRange: IntRange,
     spareFilterMax: Int,
-    action: ConsumableListScreenAction,
+    action: ItemListScreenAction,
     modifier: Modifier = Modifier,
 ) {
-    val filtered =
-        remember(items, sortOrder, ddayRange, ddayFilterMax, spareRange, spareFilterMax) {
-            applyFiltersAndSort(
-                items,
-                sortOrder,
-                ddayRange,
-                ddayFilterMax,
-                spareRange,
-                spareFilterMax,
-            )
-        }
     var showFilterSheet by remember { mutableStateOf(false) }
     var showSortSheet by remember { mutableStateOf(false) }
     val lazyListState = rememberLazyListState()
@@ -114,10 +103,10 @@ internal fun ConsumableListScreenContent(
                 ),
             verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
         ) {
-            if (filtered.isEmpty()) {
+            if (items.isEmpty()) {
                 item { ConsumableListEmptyState(modifier = Modifier.fillParentMaxWidth()) }
             } else {
-                items(filtered) { item -> QuickItemListItem(item = item, onItemClick = action.onItemClick) }
+                items(items) { item -> QuickItemListItem(item = item, onItemClick = action.onItemClick) }
             }
         }
         ListFilterBar(
@@ -581,43 +570,6 @@ private fun ConsumableListEmptyState(modifier: Modifier = Modifier) {
         )
     }
 }
-
-@Suppress("LongParameterList")
-private fun applyFiltersAndSort(
-    items: List<HomeItemCard>,
-    sortOrder: ConsumableListSortOrder,
-    ddayRange: IntRange,
-    ddayFilterMax: Int,
-    spareRange: IntRange,
-    spareFilterMax: Int,
-): List<HomeItemCard> {
-    val ddayFiltered =
-        if (ddayFilterMax >= ddayRange.last) {
-            items
-        } else {
-            items.filter { parseDaysUntil(it.replacementDday) <= ddayFilterMax }
-        }
-    val spareFiltered =
-        if (spareFilterMax >= spareRange.last) {
-            ddayFiltered
-        } else {
-            ddayFiltered.filter { it.spareQuantity <= spareFilterMax }
-        }
-    return when (sortOrder) {
-        ConsumableListSortOrder.REPLACE_IMMINENT -> spareFiltered.sortedBy { parseDaysUntil(it.replacementDday) }
-        ConsumableListSortOrder.LEAST_SPARE -> spareFiltered.sortedBy { it.spareQuantity }
-        ConsumableListSortOrder.OLDEST_REPLACEMENT -> spareFiltered.sortedByDescending { it.daysInUse }
-        ConsumableListSortOrder.ALPHABETICAL -> spareFiltered.sortedBy { it.name }
-    }
-}
-
-private fun parseDaysUntil(replacementDday: String): Int =
-    when {
-        replacementDday.contains("D-day") -> 0
-        replacementDday.contains("D+") -> -(replacementDday.substringAfter("D+").toIntOrNull() ?: 0)
-        replacementDday.contains("D-") -> replacementDday.substringAfter("D-").toIntOrNull() ?: 0
-        else -> 0
-    }
 
 @Composable
 private fun SortBottomSheet(

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemOrbitSection.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemOrbitSection.kt
@@ -11,11 +11,14 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -47,10 +50,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
 import com.obrit.android.core.designsystem.theme.OBRitTheme
 import com.obrit.android.feature.home.R
 import com.obrit.obrit.shared.designsystem.tokens.atom.spacing.AtomSpacing
@@ -59,6 +64,7 @@ import com.obrit.obrit.shared.model.home.HomeItemCard
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.hypot
+import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -73,37 +79,14 @@ import kotlin.math.sqrt
 internal fun ItemOrbitSection(
     items: List<HomeItemCard>,
     normalRatio: Float,
-    warningRatio: Float,
+    negativeRatio: Float,
     modifier: Modifier = Modifier,
 ) {
-    val density = LocalDensity.current
-    val itemCount = items.size
-
-    // 물리 상태 전체를 density와 itemCount 기준으로 관리한다.
-    val physicsState = remember(density, itemCount) { GlassBallPhysicsState(density, itemCount) }
-
-    val iconOffsets =
-        remember(density, itemCount) {
-            Array(itemCount) { i -> mutableStateOf(physicsState.initOffsets.getOrNull(i) ?: Offset.Zero) }
-        }
-
-    // 물리 시뮬레이션 루프: withFrameNanos로 화면 주사율(≈60fps)에 동기화한다.
-    LaunchedEffect(itemCount) {
-        var lastTime = 0L
-        while (true) {
-            withFrameNanos { time ->
-                // 프레임 간 경과 시간(초). 첫 프레임은 기본값 사용, 이후 실제 경과 시간을 사용한다.
-                val dt = if (lastTime == 0L) DEFAULT_DT else ((time - lastTime) / NANOS_PER_SECOND).coerceIn(0f, MAX_DT)
-                lastTime = time
-                stepPhysicsFrame(physicsState, dt, iconOffsets)
-            }
-        }
-    }
-
+    val (physicsState, iconOffsets) = rememberGlassBallPhysics(items.size)
     val tilt = rememberGlassBallTilt()
 
     Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-        GlassBallStatusRing(normalRatio = normalRatio, warningRatio = warningRatio)
+        GlassBallStatusRing(normalRatio = normalRatio, warningRatio = negativeRatio)
         GlassBallGroundShadow()
         GlassBallContent(
             items = items,
@@ -111,12 +94,45 @@ internal fun ItemOrbitSection(
             visualState =
                 GlassBallVisualState(
                     normalRatio = normalRatio,
-                    warningRatio = warningRatio,
+                    warningRatio = negativeRatio,
                     tilt = tilt,
                 ),
             iconOffsets = iconOffsets,
         )
+        GlassBallRatioLabel(
+            ratio = normalRatio,
+            label = "양호",
+            color = Color(SemanticColors.Text.Positive.Default),
+            modifier = Modifier.align(Alignment.CenterStart).padding(start = 20.dp),
+        )
+        GlassBallRatioLabel(
+            ratio = negativeRatio,
+            label = "경고",
+            color = Color(SemanticColors.Text.Warning.Default),
+            modifier = Modifier.align(Alignment.CenterEnd).padding(end = 20.dp),
+        )
     }
+}
+
+@Composable
+private fun rememberGlassBallPhysics(itemCount: Int): Pair<GlassBallPhysicsState, Array<MutableState<Offset>>> {
+    val density = LocalDensity.current
+    val physicsState = remember(density, itemCount) { GlassBallPhysicsState(density, itemCount) }
+    val iconOffsets =
+        remember(density, itemCount) {
+            Array(itemCount) { i -> mutableStateOf(physicsState.initOffsets.getOrNull(i) ?: Offset.Zero) }
+        }
+    LaunchedEffect(itemCount) {
+        var lastTime = 0L
+        while (true) {
+            withFrameNanos { time ->
+                val dt = if (lastTime == 0L) DEFAULT_DT else ((time - lastTime) / NANOS_PER_SECOND).coerceIn(0f, MAX_DT)
+                lastTime = time
+                stepPhysicsFrame(physicsState, dt, iconOffsets)
+            }
+        }
+    }
+    return physicsState to iconOffsets
 }
 
 /** 중력 센서를 읽어 [-1, 1]로 정규화된 기기 기울기를 반환한다. 센서 미지원 시 Offset.Zero를 반환한다. */
@@ -839,7 +855,7 @@ private val StaticRotationCycle = floatArrayOf(25f, -20f, -15f, 15f)
 @Suppress("MagicNumber")
 private val MassFactorCycle = floatArrayOf(0.7f, 1.0f, 1.4f, 0.9f)
 
-private val ORBIT_ICON_SIZE = AtomSpacing.S14.dp
+private val ORBIT_ICON_SIZE = AtomSpacing.S24.dp
 
 // 텍스처 그래디언트 마스크 stop 위치 (iOS: HomeOrbGlassMetrics.textureMaskStops)
 private const val TEXTURE_MASK_STOP_1 = 0.38f
@@ -850,6 +866,28 @@ private const val TEXTURE_MASK_ALPHA_038 = 0.44f // 1 - 0.56
 private const val TEXTURE_MASK_ALPHA_068 = 0.82f // 1 - 0.18
 private const val TEXTURE_MASK_ALPHA_100 = 0.94f // 1 - 0.06
 
+@Composable
+private fun GlassBallRatioLabel(
+    ratio: Float,
+    label: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    val typography = LocalOBRitTypography.current
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = "${(ratio * 100).roundToInt()}%",
+            style = typography.xl3.copy(fontWeight = FontWeight.Bold),
+            color = color,
+        )
+        Text(
+            text = label,
+            style = typography.xs,
+            color = color,
+        )
+    }
+}
+
 @Preview(showBackground = true, backgroundColor = 0xFF1D1B20)
 @Composable
 private fun ItemOrbitSectionPreview() {
@@ -857,7 +895,7 @@ private fun ItemOrbitSectionPreview() {
         ItemOrbitSection(
             items = emptyList(),
             normalRatio = 0.62f,
-            warningRatio = 0.38f,
+            negativeRatio = 0.38f,
         )
     }
 }

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemUsageStatusSection.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemUsageStatusSection.kt
@@ -3,7 +3,6 @@ package com.obrit.feature.home.screen.homeSection
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.obrit.android.core.designsystem.R
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
 import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
@@ -77,11 +78,14 @@ private fun UsageStatusItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(AtomSpacing.S3.dp),
     ) {
-        Box(
+        AsyncImage(
+            model = item.iconUrl,
+            contentDescription = null,
             modifier =
                 Modifier
                     .size(AtomSpacing.S10.dp)
-                    .background(color = colors.gray700, shape = CircleShape),
+                    .clip(CircleShape)
+                    .background(color = colors.gray700),
         )
 
         Text(

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemUsageStatusSection.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemUsageStatusSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -88,6 +89,8 @@ private fun UsageStatusItem(
             style = typography.base.copy(fontWeight = FontWeight.Medium),
             color = colors.common00,
             modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
 
         DaysInUseText(daysInUse = item.daysInUse)

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/QuickItemSection.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/QuickItemSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.obrit.android.core.designsystem.component.card.OBRitCardGrid
 import com.obrit.android.core.designsystem.component.card.OBRitCardLevel
 import com.obrit.android.core.designsystem.component.chip.OBRitChip
@@ -114,6 +115,7 @@ private fun BucketCard(
         stockCount = item.spareQuantity,
         daysLabel = daysLabel(item.nextReplacementDate),
         modifier = Modifier.clickable { onItemClick(item.itemId) },
+        image = { AsyncImage(model = item.iconUrl, contentDescription = null) },
     )
 }
 
@@ -159,6 +161,7 @@ private val previewBuckets =
                     HomeBucketItem(
                         itemId = 1,
                         name = "면도기",
+                        iconUrl = "",
                         spareQuantity = 0,
                         nextReplacementDate = ReplacementDate("2026-05-23"),
                         status = HomeStatusLevel.DANGER,
@@ -167,6 +170,7 @@ private val previewBuckets =
                     HomeBucketItem(
                         itemId = 2,
                         name = "칫솔",
+                        iconUrl = "",
                         spareQuantity = 1,
                         nextReplacementDate = ReplacementDate("2026-05-26"),
                         status = HomeStatusLevel.DANGER,
@@ -182,6 +186,7 @@ private val previewBuckets =
                     HomeBucketItem(
                         itemId = 3,
                         name = "필터",
+                        iconUrl = "",
                         spareQuantity = 3,
                         nextReplacementDate = ReplacementDate("2026-05-26"),
                         status = HomeStatusLevel.WARNING,

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -58,11 +58,16 @@ class HomeViewModel internal constructor(
 
     fun onListSortOrderChange(sortOrder: ConsumableListSortOrder) =
         intent {
+            val current = state as? HomeUiState.Success ?: return@intent
             reduceOn<HomeUiState.Success> { state.copy(listSortOrder = sortOrder) }
-            Log.d(TAG, "getItems called: order=${sortOrder.toHomeItemOrder()}")
-            val itemsResult = homeRepository.getItems(HomeItemsParams(order = sortOrder.toHomeItemOrder()))
-            Log.d(TAG, "getItems response: $itemsResult")
-            val items = itemsResult.getOrNull()
+            val params =
+                HomeItemsParams(
+                    order = sortOrder.toHomeItemOrder(),
+                    dDay = if (current.ddayFilterMax < current.ddayRange.last) current.ddayFilterMax else null,
+                    spareQuantity = if (current.spareFilterMax < current.spareRange.last) current.spareFilterMax else null,
+                )
+            Log.d(TAG, "getItems called: $params")
+            val items = homeRepository.getItems(params).also { Log.d(TAG, "getItems response: $it") }.getOrNull()
             if (items != null) {
                 reduceOn<HomeUiState.Success> { state.copy(items = items) }
             }
@@ -119,7 +124,6 @@ class HomeViewModel internal constructor(
         intent {
             val current = state as? HomeUiState.Success ?: return@intent
             if (!current.items.hasNext) return@intent
-            Log.d(TAG, "getItems called: order=${current.listSortOrder.toHomeItemOrder()}, cursor=${current.items.nextCursor}")
             val loadMoreResult =
                 homeRepository
                     .getItems(
@@ -128,7 +132,6 @@ class HomeViewModel internal constructor(
                             cursor = current.items.nextCursor,
                         ),
                     )
-            Log.d(TAG, "getItems response: $loadMoreResult")
             val result = loadMoreResult.getOrNull() ?: return@intent
             reduceOn<HomeUiState.Success> {
                 state.copy(

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -6,6 +6,7 @@ import com.obrit.android.core.ui.BaseContainerHost
 import com.obrit.android.core.ui.extensions.vmAsync
 import com.obrit.obrit.shared.data.repository.HomeRepository
 import com.obrit.obrit.shared.model.home.HomeBucketGroup
+import com.obrit.obrit.shared.model.home.HomeItemCard
 import com.obrit.obrit.shared.model.home.HomeItemCursorSlice
 import com.obrit.obrit.shared.model.home.HomeItemOrder
 import com.obrit.obrit.shared.model.home.HomeItemsParams
@@ -30,6 +31,11 @@ class HomeViewModel internal constructor(
                     Log.d(TAG, "getItems called: order=${HomeItemOrder.REPLACEMENT_URGENT}")
                     homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.REPLACEMENT_URGENT))
                 }
+            val usageItemsDeferred =
+                vmAsync {
+                    Log.d(TAG, "getItems called: order=${HomeItemOrder.USED_OLD}")
+                    homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.USED_OLD))
+                }
 
             val overallStatus = overallStatusDeferred.await().getOrNull()
             val myStatusSummaryResult = myStatusSummaryDeferred.await()
@@ -41,13 +47,16 @@ class HomeViewModel internal constructor(
             val itemsResult = itemsDeferred.await()
             Log.d(TAG, "getItems response: $itemsResult")
             val items = itemsResult.getOrNull()
-            val allLoaded = overallStatus != null && myStatusSummary != null && buckets != null && items != null
+            val usageItemsResult = usageItemsDeferred.await()
+            Log.d(TAG, "getUsageItems response: $usageItemsResult")
+            val usageItems = usageItemsResult.getOrNull()
+            val allLoaded = overallStatus != null && myStatusSummary != null && buckets != null && items != null && usageItems != null
             if (!allLoaded) {
                 reduce { HomeUiState.LoadFailed }
                 return@container
             }
 
-            reduce { createSuccessState(overallStatus, myStatusSummary, buckets, items, createMockStatus()) }
+            reduce { createSuccessState(overallStatus, myStatusSummary, buckets, items, usageItems.content, createMockStatus()) }
         }
 
     fun onSearchClick() = intent { postSideEffect(HomeSideEffect.OnSearchClick) }
@@ -71,13 +80,15 @@ class HomeViewModel internal constructor(
             val myStatusSummaryDeferred = vmAsync { homeRepository.getMyStatusSummary() }
             val bucketsDeferred = vmAsync { homeRepository.getBuckets() }
             val itemsDeferred = vmAsync { homeRepository.getItems(params) }
+            val usageItemsDeferred = vmAsync { homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.USED_OLD)) }
 
             val overallStatus = overallStatusDeferred.await().getOrNull() ?: return@intent
             val myStatusSummary = myStatusSummaryDeferred.await().getOrNull() ?: return@intent
             val buckets = bucketsDeferred.await().getOrNull() ?: return@intent
             val items = itemsDeferred.await().getOrNull() ?: return@intent
+            val usageItems = usageItemsDeferred.await().getOrNull() ?: return@intent
 
-            val refreshed = createSuccessState(overallStatus, myStatusSummary, buckets, items, current.status)
+            val refreshed = createSuccessState(overallStatus, myStatusSummary, buckets, items, usageItems.content, current.status)
             reduceOn<HomeUiState.Success> {
                 refreshed.copy(
                     listSortOrder = current.listSortOrder,
@@ -201,6 +212,7 @@ sealed interface HomeUiState {
         val myStatusSummary: MyStatusSummary,
         val buckets: List<HomeBucketGroup>,
         val items: HomeItemCursorSlice,
+        val usageItems: List<HomeItemCard>,
         val status: HomeStatus,
         val listSortOrder: ConsumableListSortOrder = ConsumableListSortOrder.REPLACE_IMMINENT,
         val ddayRange: IntRange,
@@ -245,12 +257,13 @@ enum class ConsumableListSortOrder(
     ALPHABETICAL("가나다 순"),
 }
 
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "LongParameterList")
 private fun createSuccessState(
     overallStatus: HomeOverallStatus,
     myStatusSummary: MyStatusSummary,
     buckets: List<HomeBucketGroup>,
     items: HomeItemCursorSlice,
+    usageItems: List<HomeItemCard>,
     status: HomeStatus,
 ): HomeUiState.Success {
     val ddayValues = items.content.map { parseDday(it.replacementDday) }
@@ -264,6 +277,7 @@ private fun createSuccessState(
         myStatusSummary = myStatusSummary,
         buckets = buckets,
         items = items,
+        usageItems = usageItems,
         status = status,
         ddayRange = ddayMin..ddayMax,
         ddayFilterMax = ddayMax,

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -56,6 +56,47 @@ class HomeViewModel internal constructor(
 
     fun onProfileClick() = intent { postSideEffect(HomeSideEffect.OnProfileClick) }
 
+    fun onHomeResumed() =
+        intent {
+            val current = state as? HomeUiState.Success ?: return@intent
+            val isDdayFilterApplied = current.ddayFilterMax < current.ddayRange.last
+            val isSpareFilterApplied = current.spareFilterMax < current.spareRange.last
+            val params =
+                HomeItemsParams(
+                    order = current.listSortOrder.toHomeItemOrder(),
+                    dDay = if (isDdayFilterApplied) current.ddayFilterMax else null,
+                    spareQuantity = if (isSpareFilterApplied) current.spareFilterMax else null,
+                )
+            val overallStatusDeferred = vmAsync { homeRepository.getOverallStatus() }
+            val myStatusSummaryDeferred = vmAsync { homeRepository.getMyStatusSummary() }
+            val bucketsDeferred = vmAsync { homeRepository.getBuckets() }
+            val itemsDeferred = vmAsync { homeRepository.getItems(params) }
+
+            val overallStatus = overallStatusDeferred.await().getOrNull() ?: return@intent
+            val myStatusSummary = myStatusSummaryDeferred.await().getOrNull() ?: return@intent
+            val buckets = bucketsDeferred.await().getOrNull() ?: return@intent
+            val items = itemsDeferred.await().getOrNull() ?: return@intent
+
+            val refreshed = createSuccessState(overallStatus, myStatusSummary, buckets, items, current.status)
+            reduceOn<HomeUiState.Success> {
+                refreshed.copy(
+                    listSortOrder = current.listSortOrder,
+                    ddayFilterMax =
+                        if (isDdayFilterApplied) {
+                            current.ddayFilterMax.coerceIn(refreshed.ddayRange)
+                        } else {
+                            refreshed.ddayRange.last
+                        },
+                    spareFilterMax =
+                        if (isSpareFilterApplied) {
+                            current.spareFilterMax.coerceIn(refreshed.spareRange)
+                        } else {
+                            refreshed.spareRange.last
+                        },
+                )
+            }
+        }
+
     fun onListSortOrderChange(sortOrder: ConsumableListSortOrder) =
         intent {
             val current = state as? HomeUiState.Success ?: return@intent

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/home/HomeBucketItem.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/home/HomeBucketItem.kt
@@ -5,6 +5,7 @@ import com.obrit.obrit.shared.model.ReplacementDate
 data class HomeBucketItem(
     val itemId: Long,
     val name: String,
+    val iconUrl: String,
     val spareQuantity: Int,
     val nextReplacementDate: ReplacementDate?,
     val status: HomeStatusLevel,

--- a/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/home/BucketItemResponse.kt
+++ b/shared/network/src/commonMain/kotlin/com/obrit/obrit/shared/network/response/home/BucketItemResponse.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 data class BucketItemResponse(
     @SerialName("itemId") val itemId: Long,
     @SerialName("name") val name: String,
+    @SerialName("iconUrl") val iconUrl: String,
     @SerialName("spareQuantity") val spareQuantity: Int,
     @SerialName("nextReplacementDate") val nextReplacementDate: String? = null,
     @SerialName("status") val status: String,
@@ -21,6 +22,7 @@ fun BucketItemResponse.toHomeBucketItem() =
     HomeBucketItem(
         itemId = itemId,
         name = name,
+        iconUrl = iconUrl,
         spareQuantity = spareQuantity,
         nextReplacementDate = nextReplacementDate?.let(::ReplacementDate),
         status =


### PR DESCRIPTION
### 작업 요약

- 홈 화면 API 연동 관련 버그 수정 및 기능 개선

### 관련 이슈

- #131 

### 변경 사항

- HomeScreen 재진입 시 API 재호출 (onHomeResumed) — 첫 로딩 시 중복 호출 방지
- ItemUsageStatusSection 아이템 목록을 `order=USED_OLD` 로 별도 API 호출하도록 수정
- ItemUsageStatusSection, QuickItemSection 에서 iconUrl 로 소모품 이미지 표시
- HomeScreenFailureContent 구현 — 로딩 실패 시 에러 화면 표시
- 리스트 탭에서 정렬 변경 시 기존 필터값(D-day, 여분) 유지되도록 수정
- 물건 궤도 상태 비율을 `needReplaceCount / totalCount` 로 계산
- 소모품 명이 길어질 경우 최대 1줄 (maxLines = 1) 처리 (공통 컴포넌트 수정)

### 변경 이유

- 홈 화면 재진입 시 데이터가 갱신되지 않아 최신 상태가 반영되지 않는 문제
- 사용 현황 섹션이 교체 임박 순 대신 오래된 사용 순으로 보여져야 함
- 소모품 이미지가 표시되지 않아 UI 완성도가 낮은 문제
- 로딩 실패 시 빈 화면이 노출되어 사용자에게 피드백이 없는 문제
- 정렬 변경 시 필터가 초기화되어 사용자 경험이 저하되는 문제

### 영향 범위

- [x] 일반 기능 변경
- [x] UI 변경
- [x] API 연동 변경
- [x] 공통 컴포넌트 변경
- [ ] 시스템 영향 가능 (`lint`, `gradle`, `manifest`, build config 등)

> 시스템 영향 변경이 포함된 경우 리뷰어 2인 승인 기준을 적용할 수 있습니다.

### 리뷰 요청 포인트

- 공통 컴포넌트 수정

### 테스트 / 검증

- [x] build 통과
- [x] ktlint 통과
- [x] detekt 통과
- [ ] unit test 통과
- [x] 수동 테스트 완료

### 스크린샷 / 영상
<img width="240" height="540" alt="image" src="https://github.com/user-attachments/assets/d61b40fe-4da9-4048-8a12-273b89b6a114" />



### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#이슈번호-기능명`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식 (`feat: ...`, `fix: ...`, `refactor: ...`)
- [x] self-review 완료
- [ ] 문서 반영 필요 시 반영 완료