### PR TITLE
feat: Android 홈 API, UI 수정 (#133)

### DIFF
--- a/android/core/designsystem/src/main/java/com/obrit/android/core/designsystem/component/card/OBRitCard.kt
+++ b/android/core/designsystem/src/main/java/com/obrit/android/core/designsystem/component/card/OBRitCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -19,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -110,6 +112,7 @@ fun OBRitCardList(
     val colors = LocalOBRitColor.current
     val typography = LocalOBRitTypography.current
     val badgeStyle = typography.xs.copy(fontWeight = FontWeight.Bold)
+    val badgeMaxWidth = LocalConfiguration.current.screenWidthDp.dp * BADGE_ROW_MAX_WIDTH_FRACTION
 
     Row(
         modifier =
@@ -150,10 +153,15 @@ fun OBRitCardList(
                     text = "째 사용중",
                     style = typography.s.copy(fontWeight = FontWeight.Medium),
                     color = listInUseSuffixColor(colors = colors, level = level),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(AtomSpacing.S1.dp)) {
+        Row(
+            modifier = Modifier.widthIn(max = badgeMaxWidth),
+            horizontalArrangement = Arrangement.spacedBy(AtomSpacing.S1.dp),
+        ) {
             CardBadge(
                 text = replaceLabel,
                 containerColor = listFirstBadgeContainerColor(colors = colors, level = level),
@@ -284,6 +292,7 @@ private val OBRitCardShape = RoundedCornerShape(AtomRadius.ExtraLarge.dp)
 private val OBRitCardBadgeShape = RoundedCornerShape(AtomRadius.Small.dp)
 private val GridCardSize = 160.dp
 private val ListImageSize = 48.dp
+private const val BADGE_ROW_MAX_WIDTH_FRACTION = 0.5f
 
 @Preview(name = "OBRitCardGrid L1", showBackground = true)
 @Composable

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +35,7 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -42,6 +45,7 @@ import com.obrit.android.core.designsystem.component.gnb.OBRitGnb
 import com.obrit.android.core.designsystem.component.gnb.OBRitGnbTab
 import com.obrit.android.core.designsystem.component.topbar.OBRitHomeTopBar
 import com.obrit.android.core.designsystem.theme.LocalOBRitColor
+import com.obrit.android.core.designsystem.theme.LocalOBRitTypography
 import com.obrit.feature.home.screen.homeSection.ItemListPreviewSection
 import com.obrit.feature.home.screen.homeSection.ItemOrbitSection
 import com.obrit.feature.home.screen.homeSection.ItemStatusSection
@@ -217,32 +221,57 @@ private fun HomeContents(
             currentOnLoadMoreItems()
         }
     }
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .verticalScroll(scrollState)
-                .navigationBarsPadding()
-                .padding(bottom = 80.dp),
-    ) {
-        ItemStatusSection(overallStatus = state.overallStatus)
-        val totalCount = state.myStatusSummary.totalCount.coerceAtLeast(1)
-        val negativeRatio = state.myStatusSummary.needReplaceCount.toFloat() / totalCount
-        ItemOrbitSection(
-            items = state.items.content.take(ORBIT_ITEMS_SIZE),
-            normalRatio = 1f - negativeRatio,
-            negativeRatio = negativeRatio,
-        )
-        MyStatusGraphSection(myStatusSummary = state.myStatusSummary)
-        QuickItemSection(buckets = state.buckets, onItemClick = onItemClick)
-        ItemListPreviewSection(
-            items = state.items.content,
-            sortOrder = state.listSortOrder,
-            onSortOrderChange = onListSortOrderChange,
-            onMoreClick = onMoreClick,
-            onItemClick = onItemClick,
-        )
-        ItemUsageStatusSection(items = state.items.content, onItemClick = onItemClick)
+    if (state.items.content.isEmpty()) {
+        val typography = LocalOBRitTypography.current
+        val colors = LocalOBRitColor.current
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
+            ) {
+                Text(
+                    text = "아직 등록된 소모품이 없어요.",
+                    style = typography.xl3.copy(fontWeight = FontWeight.Bold),
+                    color = colors.common00,
+                )
+                Text(
+                    text = "하단 + 버튼으로 소모품을 등록해보세요!",
+                    style = typography.base.copy(fontWeight = FontWeight.Medium),
+                    color = colors.gray300,
+                )
+            }
+        }
+    } else {
+        Column(
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .verticalScroll(scrollState)
+                    .navigationBarsPadding()
+                    .padding(bottom = 80.dp),
+        ) {
+            ItemStatusSection(overallStatus = state.overallStatus)
+            val totalCount = state.myStatusSummary.totalCount.coerceAtLeast(1)
+            val negativeRatio = state.myStatusSummary.needReplaceCount.toFloat() / totalCount
+            ItemOrbitSection(
+                items = state.items.content.take(ORBIT_ITEMS_SIZE),
+                normalRatio = 1f - negativeRatio,
+                negativeRatio = negativeRatio,
+            )
+            MyStatusGraphSection(myStatusSummary = state.myStatusSummary)
+            QuickItemSection(buckets = state.buckets, onItemClick = onItemClick)
+            ItemListPreviewSection(
+                items = state.items.content,
+                sortOrder = state.listSortOrder,
+                onSortOrderChange = onListSortOrderChange,
+                onMoreClick = onMoreClick,
+                onItemClick = onItemClick,
+            )
+            ItemUsageStatusSection(items = state.items.content, onItemClick = onItemClick)
+        }
     }
 }
 

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -3,6 +3,7 @@ package com.obrit.feature.home.screen
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +15,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -222,56 +222,81 @@ private fun HomeContents(
         }
     }
     if (state.items.content.isEmpty()) {
-        val typography = LocalOBRitTypography.current
-        val colors = LocalOBRitColor.current
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
-            ) {
-                Text(
-                    text = "아직 등록된 소모품이 없어요.",
-                    style = typography.xl3.copy(fontWeight = FontWeight.Bold),
-                    color = colors.common00,
-                )
-                Text(
-                    text = "하단 + 버튼으로 소모품을 등록해보세요!",
-                    style = typography.base.copy(fontWeight = FontWeight.Medium),
-                    color = colors.gray300,
-                )
-            }
-        }
+        HomeContentsEmptyState()
     } else {
+        HomeContentsItemList(
+            state = state,
+            scrollState = scrollState,
+            onListSortOrderChange = onListSortOrderChange,
+            onMoreClick = onMoreClick,
+            onItemClick = onItemClick,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun HomeContentsEmptyState() {
+    val typography = LocalOBRitTypography.current
+    val colors = LocalOBRitColor.current
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
         Column(
-            modifier =
-                modifier
-                    .fillMaxWidth()
-                    .verticalScroll(scrollState)
-                    .navigationBarsPadding()
-                    .padding(bottom = 80.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
         ) {
-            ItemStatusSection(overallStatus = state.overallStatus)
-            val totalCount = state.myStatusSummary.totalCount.coerceAtLeast(1)
-            val negativeRatio = state.myStatusSummary.needReplaceCount.toFloat() / totalCount
-            ItemOrbitSection(
-                items = state.items.content.take(ORBIT_ITEMS_SIZE),
-                normalRatio = 1f - negativeRatio,
-                negativeRatio = negativeRatio,
+            Text(
+                text = "아직 등록된 소모품이 없어요.",
+                style = typography.xl3.copy(fontWeight = FontWeight.Bold),
+                color = colors.common00,
             )
-            MyStatusGraphSection(myStatusSummary = state.myStatusSummary)
-            QuickItemSection(buckets = state.buckets, onItemClick = onItemClick)
-            ItemListPreviewSection(
-                items = state.items.content,
-                sortOrder = state.listSortOrder,
-                onSortOrderChange = onListSortOrderChange,
-                onMoreClick = onMoreClick,
-                onItemClick = onItemClick,
+            Text(
+                text = "하단 + 버튼으로 소모품을 등록해보세요!",
+                style = typography.base.copy(fontWeight = FontWeight.Medium),
+                color = colors.gray300,
             )
-            ItemUsageStatusSection(items = state.items.content, onItemClick = onItemClick)
         }
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun HomeContentsItemList(
+    state: HomeUiState.Success,
+    scrollState: ScrollState,
+    onListSortOrderChange: (ConsumableListSortOrder) -> Unit,
+    onMoreClick: () -> Unit,
+    onItemClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val totalCount = state.myStatusSummary.totalCount.coerceAtLeast(1)
+    val negativeRatio = state.myStatusSummary.needReplaceCount.toFloat() / totalCount
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .verticalScroll(scrollState)
+                .navigationBarsPadding()
+                .padding(bottom = 80.dp),
+    ) {
+        ItemStatusSection(overallStatus = state.overallStatus)
+        ItemOrbitSection(
+            items = state.items.content.take(ORBIT_ITEMS_SIZE),
+            normalRatio = 1f - negativeRatio,
+            negativeRatio = negativeRatio,
+        )
+        MyStatusGraphSection(myStatusSummary = state.myStatusSummary)
+        QuickItemSection(buckets = state.buckets, onItemClick = onItemClick)
+        ItemListPreviewSection(
+            items = state.items.content,
+            sortOrder = state.listSortOrder,
+            onSortOrderChange = onListSortOrderChange,
+            onMoreClick = onMoreClick,
+            onItemClick = onItemClick,
+        )
+        ItemUsageStatusSection(items = state.items.content, onItemClick = onItemClick)
     }
 }
 

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/HomeScreenSuccessContent.kt
@@ -242,7 +242,7 @@ private fun HomeContents(
             onMoreClick = onMoreClick,
             onItemClick = onItemClick,
         )
-        ItemUsageStatusSection(items = state.usageItems, onItemClick = onItemClick)
+        ItemUsageStatusSection(items = state.items.content, onItemClick = onItemClick)
     }
 }
 

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemUsageStatusSection.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/ItemUsageStatusSection.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -99,13 +98,11 @@ private fun UsageStatusItem(
 
         DaysInUseText(daysInUse = item.daysInUse)
 
-        Spacer(modifier = Modifier.size(AtomSpacing.S4.dp))
-
         Icon(
             painter = painterResource(id = R.drawable.ic_chevron_right),
             contentDescription = null,
             tint = colors.common00,
-            modifier = Modifier.size(AtomSpacing.S4.dp),
+            modifier = Modifier.padding(start = AtomSpacing.S1.dp).size(AtomSpacing.S4.dp),
         )
     }
 }

--- a/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/QuickItemSection.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/screen/homeSection/QuickItemSection.kt
@@ -43,7 +43,14 @@ internal fun QuickItemSection(
 ) {
     if (buckets.isEmpty()) return
     val hasDangerItems = buckets.find { it.bucket == HomeBucketType.DANGER }?.items?.isNotEmpty() == true
-    var selectedType by remember { mutableStateOf(if (hasDangerItems) buckets.first().bucket else buckets.last().bucket) }
+    val hasWarningItems = buckets.find { it.bucket == HomeBucketType.WARNING }?.items?.isNotEmpty() == true
+    val defaultSelectedType =
+        when {
+            hasDangerItems -> HomeBucketType.DANGER
+            hasWarningItems -> HomeBucketType.WARNING
+            else -> buckets.firstOrNull { it.items.isNotEmpty() }?.bucket ?: buckets.first().bucket
+        }
+    var selectedType by remember { mutableStateOf(defaultSelectedType) }
     val selectedItems =
         remember(buckets, selectedType) {
             buckets.find { it.bucket == selectedType }?.items ?: emptyList()

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -67,12 +67,14 @@ class HomeViewModel internal constructor(
             myStatusSummaryDeferred.await().getOrNull()?.let { myStatusSummary ->
                 reduceOn<HomeUiState.Success> { state.copy(myStatusSummary = myStatusSummary) }
             }
-            bucketsDeferred.await().getOrNull()?.let { buckets ->
-                reduceOn<HomeUiState.Success> { state.copy(buckets = buckets) }
-            }
-            itemsDeferred.await().getOrNull()?.let { items ->
+            val buckets = bucketsDeferred.await().getOrNull()
+            val items = itemsDeferred.await().getOrNull()
+            if (buckets != null || items != null) {
                 reduceOn<HomeUiState.Success> {
-                    state.withRefreshedItems(items, isDdayFilterApplied, isSpareFilterApplied)
+                    var newState = state
+                    if (buckets != null) newState = newState.copy(buckets = buckets)
+                    if (items != null) newState = newState.withRefreshedItems(items, isDdayFilterApplied, isSpareFilterApplied)
+                    newState
                 }
             }
             usageItemsDeferred.await().getOrNull()?.let { usageItems ->

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -316,5 +316,5 @@ private fun ConsumableListSortOrder.toHomeItemOrder(): HomeItemOrder? =
         ConsumableListSortOrder.REPLACE_IMMINENT -> HomeItemOrder.REPLACEMENT_URGENT
         ConsumableListSortOrder.LEAST_SPARE -> HomeItemOrder.SPARE_LOW
         ConsumableListSortOrder.OLDEST_REPLACEMENT -> HomeItemOrder.USED_OLD
-        ConsumableListSortOrder.ALPHABETICAL -> null
+        ConsumableListSortOrder.ALPHABETICAL -> HomeItemOrder.ITEM_NAME
     }

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.obrit.feature.home.viewmodel
 
-import android.util.Log
 import androidx.compose.runtime.Immutable
 import com.obrit.android.core.ui.BaseContainerHost
 import com.obrit.android.core.ui.extensions.vmAsync
@@ -21,35 +20,15 @@ class HomeViewModel internal constructor(
         container<HomeUiState, HomeSideEffect>(HomeUiState.Loading) {
             val overallStatusDeferred = vmAsync { homeRepository.getOverallStatus() }
             val myStatusSummaryDeferred = vmAsync { homeRepository.getMyStatusSummary() }
-            val bucketsDeferred =
-                vmAsync {
-                    Log.d(TAG, "getBuckets called")
-                    homeRepository.getBuckets()
-                }
-            val itemsDeferred =
-                vmAsync {
-                    Log.d(TAG, "getItems called: order=${HomeItemOrder.REPLACEMENT_URGENT}")
-                    homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.REPLACEMENT_URGENT))
-                }
-            val usageItemsDeferred =
-                vmAsync {
-                    Log.d(TAG, "getItems called: order=${HomeItemOrder.USED_OLD}")
-                    homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.USED_OLD))
-                }
+            val bucketsDeferred = vmAsync { homeRepository.getBuckets() }
+            val itemsDeferred = vmAsync { homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.REPLACEMENT_URGENT)) }
+            val usageItemsDeferred = vmAsync { homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.USED_OLD)) }
 
             val overallStatus = overallStatusDeferred.await().getOrNull()
-            val myStatusSummaryResult = myStatusSummaryDeferred.await()
-            Log.d(TAG, "getMyStatusSummary response: $myStatusSummaryResult")
-            val myStatusSummary = myStatusSummaryResult.getOrNull()
-            val bucketsResult = bucketsDeferred.await()
-            Log.d(TAG, "getBuckets response: $bucketsResult")
-            val buckets = bucketsResult.getOrNull()
-            val itemsResult = itemsDeferred.await()
-            Log.d(TAG, "getItems response: $itemsResult")
-            val items = itemsResult.getOrNull()
-            val usageItemsResult = usageItemsDeferred.await()
-            Log.d(TAG, "getUsageItems response: $usageItemsResult")
-            val usageItems = usageItemsResult.getOrNull()
+            val myStatusSummary = myStatusSummaryDeferred.await().getOrNull()
+            val buckets = bucketsDeferred.await().getOrNull()
+            val items = itemsDeferred.await().getOrNull()
+            val usageItems = usageItemsDeferred.await().getOrNull()
             val allLoaded = overallStatus != null && myStatusSummary != null && buckets != null && items != null && usageItems != null
             if (!allLoaded) {
                 reduce { HomeUiState.LoadFailed }
@@ -92,18 +71,8 @@ class HomeViewModel internal constructor(
                 reduceOn<HomeUiState.Success> { state.copy(buckets = buckets) }
             }
             itemsDeferred.await().getOrNull()?.let { items ->
-                val ddayValues = items.content.map { parseDday(it.replacementDday) }
-                val spareValues = items.content.map { it.spareQuantity }
-                val newDdayRange = (ddayValues.minOrNull() ?: DEFAULT_DDAY_MIN)..(ddayValues.maxOrNull() ?: DEFAULT_DDAY_MAX)
-                val newSpareRange = (spareValues.minOrNull() ?: DEFAULT_SPARE_MIN)..(spareValues.maxOrNull() ?: DEFAULT_SPARE_MAX)
                 reduceOn<HomeUiState.Success> {
-                    state.copy(
-                        items = items,
-                        ddayRange = newDdayRange,
-                        ddayFilterMax = if (isDdayFilterApplied) current.ddayFilterMax.coerceIn(newDdayRange) else newDdayRange.last,
-                        spareRange = newSpareRange,
-                        spareFilterMax = if (isSpareFilterApplied) current.spareFilterMax.coerceIn(newSpareRange) else newSpareRange.last,
-                    )
+                    state.withRefreshedItems(items, isDdayFilterApplied, isSpareFilterApplied)
                 }
             }
             usageItemsDeferred.await().getOrNull()?.let { usageItems ->
@@ -121,8 +90,7 @@ class HomeViewModel internal constructor(
                     dDay = if (current.ddayFilterMax < current.ddayRange.last) current.ddayFilterMax else null,
                     spareQuantity = if (current.spareFilterMax < current.spareRange.last) current.spareFilterMax else null,
                 )
-            Log.d(TAG, "getItems called: $params")
-            val items = homeRepository.getItems(params).also { Log.d(TAG, "getItems response: $it") }.getOrNull()
+            val items = homeRepository.getItems(params).getOrNull()
             if (items != null) {
                 reduceOn<HomeUiState.Success> { state.copy(items = items) }
             }
@@ -138,8 +106,7 @@ class HomeViewModel internal constructor(
                     dDay = if (maxDays < current.ddayRange.last) maxDays else null,
                     spareQuantity = if (current.spareFilterMax < current.spareRange.last) current.spareFilterMax else null,
                 )
-            Log.d(TAG, "getItems called: $params")
-            val result = homeRepository.getItems(params).also { Log.d(TAG, "getItems response: $it") }.getOrNull() ?: return@intent
+            val result = homeRepository.getItems(params).getOrNull() ?: return@intent
             reduceOn<HomeUiState.Success> { state.copy(items = result) }
         }
 
@@ -153,8 +120,7 @@ class HomeViewModel internal constructor(
                     dDay = if (current.ddayFilterMax < current.ddayRange.last) current.ddayFilterMax else null,
                     spareQuantity = if (maxSpare < current.spareRange.last) maxSpare else null,
                 )
-            Log.d(TAG, "getItems called: $params")
-            val result = homeRepository.getItems(params).also { Log.d(TAG, "getItems response: $it") }.getOrNull() ?: return@intent
+            val result = homeRepository.getItems(params).getOrNull() ?: return@intent
             reduceOn<HomeUiState.Success> { state.copy(items = result) }
         }
 
@@ -170,8 +136,7 @@ class HomeViewModel internal constructor(
                 dDay = if (ddayMax < current.ddayRange.last) ddayMax else null,
                 spareQuantity = if (spareMax < current.spareRange.last) spareMax else null,
             )
-        Log.d(TAG, "getItems called: $params")
-        val result = homeRepository.getItems(params).also { Log.d(TAG, "getItems response: $it") }.getOrNull() ?: return@intent
+        val result = homeRepository.getItems(params).getOrNull() ?: return@intent
         reduceOn<HomeUiState.Success> { state.copy(items = result) }
     }
 
@@ -300,11 +265,28 @@ private fun createMockStatus() =
             ),
     )
 
-private const val TAG = "HomeViewModel"
 private const val DEFAULT_DDAY_MIN = 0
 private const val DEFAULT_DDAY_MAX = 30
 private const val DEFAULT_SPARE_MIN = 0
 private const val DEFAULT_SPARE_MAX = 10
+
+private fun HomeUiState.Success.withRefreshedItems(
+    items: HomeItemCursorSlice,
+    isDdayFilterApplied: Boolean,
+    isSpareFilterApplied: Boolean,
+): HomeUiState.Success {
+    val ddayValues = items.content.map { parseDday(it.replacementDday) }
+    val spareValues = items.content.map { it.spareQuantity }
+    val newDdayRange = (ddayValues.minOrNull() ?: DEFAULT_DDAY_MIN)..(ddayValues.maxOrNull() ?: DEFAULT_DDAY_MAX)
+    val newSpareRange = (spareValues.minOrNull() ?: DEFAULT_SPARE_MIN)..(spareValues.maxOrNull() ?: DEFAULT_SPARE_MAX)
+    return copy(
+        items = items,
+        ddayRange = newDdayRange,
+        ddayFilterMax = if (isDdayFilterApplied) ddayFilterMax.coerceIn(newDdayRange) else newDdayRange.last,
+        spareRange = newSpareRange,
+        spareFilterMax = if (isSpareFilterApplied) spareFilterMax.coerceIn(newSpareRange) else newSpareRange.last,
+    )
+}
 
 private fun parseDday(replacementDday: String): Int =
     when {

--- a/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/java/com/obrit/feature/home/viewmodel/HomeViewModel.kt
@@ -82,29 +82,32 @@ class HomeViewModel internal constructor(
             val itemsDeferred = vmAsync { homeRepository.getItems(params) }
             val usageItemsDeferred = vmAsync { homeRepository.getItems(HomeItemsParams(order = HomeItemOrder.USED_OLD)) }
 
-            val overallStatus = overallStatusDeferred.await().getOrNull() ?: return@intent
-            val myStatusSummary = myStatusSummaryDeferred.await().getOrNull() ?: return@intent
-            val buckets = bucketsDeferred.await().getOrNull() ?: return@intent
-            val items = itemsDeferred.await().getOrNull() ?: return@intent
-            val usageItems = usageItemsDeferred.await().getOrNull() ?: return@intent
-
-            val refreshed = createSuccessState(overallStatus, myStatusSummary, buckets, items, usageItems.content, current.status)
-            reduceOn<HomeUiState.Success> {
-                refreshed.copy(
-                    listSortOrder = current.listSortOrder,
-                    ddayFilterMax =
-                        if (isDdayFilterApplied) {
-                            current.ddayFilterMax.coerceIn(refreshed.ddayRange)
-                        } else {
-                            refreshed.ddayRange.last
-                        },
-                    spareFilterMax =
-                        if (isSpareFilterApplied) {
-                            current.spareFilterMax.coerceIn(refreshed.spareRange)
-                        } else {
-                            refreshed.spareRange.last
-                        },
-                )
+            overallStatusDeferred.await().getOrNull()?.let { overallStatus ->
+                reduceOn<HomeUiState.Success> { state.copy(overallStatus = overallStatus) }
+            }
+            myStatusSummaryDeferred.await().getOrNull()?.let { myStatusSummary ->
+                reduceOn<HomeUiState.Success> { state.copy(myStatusSummary = myStatusSummary) }
+            }
+            bucketsDeferred.await().getOrNull()?.let { buckets ->
+                reduceOn<HomeUiState.Success> { state.copy(buckets = buckets) }
+            }
+            itemsDeferred.await().getOrNull()?.let { items ->
+                val ddayValues = items.content.map { parseDday(it.replacementDday) }
+                val spareValues = items.content.map { it.spareQuantity }
+                val newDdayRange = (ddayValues.minOrNull() ?: DEFAULT_DDAY_MIN)..(ddayValues.maxOrNull() ?: DEFAULT_DDAY_MAX)
+                val newSpareRange = (spareValues.minOrNull() ?: DEFAULT_SPARE_MIN)..(spareValues.maxOrNull() ?: DEFAULT_SPARE_MAX)
+                reduceOn<HomeUiState.Success> {
+                    state.copy(
+                        items = items,
+                        ddayRange = newDdayRange,
+                        ddayFilterMax = if (isDdayFilterApplied) current.ddayFilterMax.coerceIn(newDdayRange) else newDdayRange.last,
+                        spareRange = newSpareRange,
+                        spareFilterMax = if (isSpareFilterApplied) current.spareFilterMax.coerceIn(newSpareRange) else newSpareRange.last,
+                    )
+                }
+            }
+            usageItemsDeferred.await().getOrNull()?.let { usageItems ->
+                reduceOn<HomeUiState.Success> { state.copy(usageItems = usageItems.content) }
             }
         }
 

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/home/HomeItemOrder.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/home/HomeItemOrder.kt
@@ -4,4 +4,5 @@ enum class HomeItemOrder {
     REPLACEMENT_URGENT,
     SPARE_LOW,
     USED_OLD,
+    ITEM_NAME,
 }


### PR DESCRIPTION
### 작업 요약

- 홈 화면의 빈 상태 처리, 카드 레이아웃 너비 제한, 소모품 추가 후 즉시 렌더링 버그, QuickItemSection 버킷 선택 초기화 버그, 사용 현황 아이템 간격 수정

### 관련 이슈

- #133 

### 변경 사항
  - 홈 화면 소모품 없을 경우 처리 추가 — items.content가 비어 있을 때 "아직 등록된 소모품이 없어요." 안내 텍스트 표시
  - OBRitCardList()의 배지 Row에 widthIn(max = screenWidthDp * 0.45f) 적용 — 좁은 화면에서 "N일째 사용중" 텍스트가 배지 영역을 침범하는 레이아웃 깨짐 수정

 - 퀵 아이템 빈 상태에서 소모품 등록 시, UI가 즉시 렌더링되지 않는 문제 수정
   - 퀵 아이템 선택된 탭 초기값을 아이템이 있는 첫 번째 버킷 순으로 명시적으로 선택하도록 수정 — API 응답의 버킷 순서와 무관하게
  올바른 탭이 선택되지 않는 버그 수정 ("위험 1" 칩은 보이지만 카드가 렌더링되지 않던 문제)
  
 - 사용 현황 우측 텍스트와 아이콘 사이 Spacer 제거

### 변경 이유
- 소모품이 없을 때 사용자에게 명확한 안내가 필요
- 좁은 기기에서 리스트 카드 레이아웃 깨짐 발생
- 소모품 추가 후 홈 재진입 시 QuickItemSection이 즉시 렌더링되지 않는 UX 문제
- API 버킷 순서에 의존한 코드로 인해 특정 조건에서 카드가 렌더링되지 않는 버그
- 디자인 스펙(16dp)과 다른 간격 적용

### 영향 범위

- [x] 일반 기능 변경
- [x] UI 변경
- [x] API 연동 변경
- [x] 공통 컴포넌트 변경
- [ ] 시스템 영향 가능 (`lint`, `gradle`, `manifest`, build config 등)

> 시스템 영향 변경이 포함된 경우 리뷰어 2인 승인 기준을 적용할 수 있습니다.

### 리뷰 요청 포인트

- 공통 컴포넌트인 OBRitCard.kt 이 방식대로 수정해도 될 지 확인 부탁드립니다.

### 테스트 / 검증

- [x] build 통과
- [x] ktlint 통과
- [x] detekt 통과
- [ ] unit test 통과
- [x] 수동 테스트 완료

### 스크린샷 / 영상
<img width="270" height="580" alt="Screenshot_20260606_010325" src="https://github.com/user-attachments/assets/2000cf85-02e5-4e5d-98a2-436b438d678a" />



### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#이슈번호-기능명`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식 (`feat: ...`, `fix: ...`, `refactor: ...`)
- [ ] self-review 완료
- [ ] 문서 반영 필요 시 반영 완료