### PR TITLE
feat: 직접 등록 이름 중복(409) 에러 표시 및 디버그 빌드 분리 (#93)

### DIFF
--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">OBRit (dev)</string>
+</resources>

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/direct/DirectRegisterScreenContent.kt
@@ -129,7 +129,11 @@ private fun DirectRegisterFieldsColumn(
                 .padding(horizontal = AtomSpacing.S5.dp),
         verticalArrangement = Arrangement.spacedBy(DIRECT_REGISTER_FIELD_GAP),
     ) {
-        NameField(value = state.name, onValueChange = onNameChange)
+        NameField(
+            value = state.name,
+            isDuplicateName = state.isDuplicateName,
+            onValueChange = onNameChange,
+        )
         IconGridField(
             label = DIRECT_REGISTER_ICON_LABEL,
             icons = state.icons,
@@ -189,9 +193,17 @@ private fun DirectRegisterCta(
 @Composable
 private fun NameField(
     value: String,
+    isDuplicateName: Boolean,
     onValueChange: (String) -> Unit,
 ) {
     val isOverLimit = value.length > DIRECT_REGISTER_NAME_MAX_LENGTH
+    val isError = isOverLimit || isDuplicateName
+    val supportingText =
+        when {
+            isOverLimit -> DIRECT_REGISTER_NAME_OVER_LIMIT_MESSAGE
+            isDuplicateName -> DIRECT_REGISTER_NAME_DUPLICATE_MESSAGE
+            else -> ""
+        }
     val focus = rememberFocusBringIntoView()
     Column(
         verticalArrangement = Arrangement.spacedBy(AtomSpacing.S3.dp),
@@ -204,11 +216,11 @@ private fun NameField(
         OBRitOutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            supportingTextEnabled = isOverLimit,
+            supportingTextEnabled = isError,
             placeholder = DIRECT_REGISTER_NAME_PLACEHOLDER,
             maxLength = DIRECT_REGISTER_NAME_MAX_LENGTH,
-            inputResultState = if (isOverLimit) InputResultState.Error else InputResultState.Default,
-            supportingText = if (isOverLimit) DIRECT_REGISTER_NAME_OVER_LIMIT_MESSAGE else "",
+            inputResultState = if (isError) InputResultState.Error else InputResultState.Default,
+            supportingText = supportingText,
             singleLine = true,
             modifier =
                 Modifier
@@ -224,6 +236,7 @@ private const val DIRECT_REGISTER_DESCRIPTION = "원하는 소모품 종류가 �
 private const val DIRECT_REGISTER_NAME_LABEL = "소모품 종류 이름"
 private const val DIRECT_REGISTER_NAME_PLACEHOLDER = "화장품 퍼프"
 private const val DIRECT_REGISTER_NAME_OVER_LIMIT_MESSAGE = "이름은 15자 이내로 입력해주세요"
+private const val DIRECT_REGISTER_NAME_DUPLICATE_MESSAGE = "중복된 이름입니다. 다른 이름으로 입력해주세요."
 private const val DIRECT_REGISTER_ICON_LABEL = "대표 이미지"
 private const val DIRECT_REGISTER_SUBMIT_LABEL = "소모품 종류 등록하기"
 

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterFields.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterFields.kt
@@ -73,9 +73,17 @@ internal fun CategoryField(
 @Composable
 internal fun NameField(
     value: String,
+    isDuplicateName: Boolean,
     onValueChange: (String) -> Unit,
 ) {
     val isOverLimit = value.length > MANUAL_REGISTER_NAME_MAX_LENGTH
+    val isError = isOverLimit || isDuplicateName
+    val supportingText =
+        when {
+            isOverLimit -> MANUAL_REGISTER_NAME_OVER_LIMIT_MESSAGE
+            isDuplicateName -> MANUAL_REGISTER_NAME_DUPLICATE_MESSAGE
+            else -> ""
+        }
     val focus = rememberFocusBringIntoView()
     Column(
         verticalArrangement = Arrangement.spacedBy(AtomSpacing.S2.dp),
@@ -88,11 +96,11 @@ internal fun NameField(
         OBRitOutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            supportingTextEnabled = isOverLimit,
+            supportingTextEnabled = isError,
             placeholder = MANUAL_REGISTER_NAME_PLACEHOLDER,
             maxLength = MANUAL_REGISTER_NAME_MAX_LENGTH,
-            inputResultState = if (isOverLimit) InputResultState.Error else InputResultState.Default,
-            supportingText = if (isOverLimit) MANUAL_REGISTER_NAME_OVER_LIMIT_MESSAGE else "",
+            inputResultState = if (isError) InputResultState.Error else InputResultState.Default,
+            supportingText = supportingText,
             singleLine = true,
             modifier =
                 Modifier
@@ -276,6 +284,7 @@ private const val MANUAL_REGISTER_NAME_LABEL = "소모품 명"
 private const val MANUAL_REGISTER_NAME_PLACEHOLDER = "구분을 위한 이름을 입력해주세요"
 private const val MANUAL_REGISTER_NAME_MAX_LENGTH = 15
 private const val MANUAL_REGISTER_NAME_OVER_LIMIT_MESSAGE = "소모품 명은 15자 이내로 입력해주세요"
+private const val MANUAL_REGISTER_NAME_DUPLICATE_MESSAGE = "중복된 이름입니다. 다른 이름으로 입력해주세요."
 private const val MANUAL_REGISTER_LAST_REPLACE_DATE_LABEL = "마지막 교체 일자"
 private const val MANUAL_REGISTER_LAST_REPLACE_DATE_PLACEHOLDER = "마지막 교체 일자를 등록해주세요"
 private const val MANUAL_REGISTER_QUANTITY_LABEL = "등록할 수량"

--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/manual/ManualRegisterScreenContent.kt
@@ -182,7 +182,11 @@ private fun ManualRegisterFields(
         verticalArrangement = Arrangement.spacedBy(MANUAL_REGISTER_FIELD_GAP),
     ) {
         CategoryField(value = state.categoryName, onClick = fieldActions.onCategoryClick)
-        NameField(value = state.name, onValueChange = fieldActions.onNameChange)
+        NameField(
+            value = state.name,
+            isDuplicateName = state.isDuplicateName,
+            onValueChange = fieldActions.onNameChange,
+        )
         LastReplaceDateField(
             selected = state.lastReplacementPeriod,
             onChange = fieldActions.onLastReplacementPeriodChange,

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/DirectRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/DirectRegisterViewModel.kt
@@ -5,6 +5,7 @@ import com.obrit.android.core.ui.BaseContainerHost
 import com.obrit.obrit.shared.data.repository.CategoryRepository
 import com.obrit.obrit.shared.model.categories.Category
 import com.obrit.obrit.shared.model.categories.CategoryIcon
+import com.obrit.obrit.shared.model.categories.error.CreateCategoryError
 import org.orbitmvi.orbit.viewmodel.container
 
 class DirectRegisterViewModel(
@@ -28,7 +29,7 @@ class DirectRegisterViewModel(
 
     fun onNameChange(value: String) =
         intent {
-            reduce { state.copy(name = value) }
+            reduce { state.copy(name = value, isDuplicateName = false) }
         }
 
     fun onIconSelect(iconId: Long) =
@@ -47,8 +48,13 @@ class DirectRegisterViewModel(
                 .onSuccess { category ->
                     reduce { state.copy(isSubmitting = false) }
                     postSideEffect(DirectRegisterSideEffect.OnRegistered(category))
-                }.onFailure {
-                    reduce { state.copy(isSubmitting = false) }
+                }.onFailure { throwable ->
+                    reduce {
+                        state.copy(
+                            isSubmitting = false,
+                            isDuplicateName = throwable is CreateCategoryError.DuplicatedName,
+                        )
+                    }
                 }
         }
 
@@ -64,13 +70,15 @@ data class DirectRegisterUiState(
     val name: String = "",
     val selectedIconId: Long? = null,
     val isSubmitting: Boolean = false,
+    val isDuplicateName: Boolean = false,
 ) {
     val isSubmitEnabled: Boolean
         get() =
             name.isNotBlank() &&
                 name.length <= DIRECT_REGISTER_NAME_MAX_LENGTH &&
                 selectedIconId != null &&
-                !isSubmitting
+                !isSubmitting &&
+                !isDuplicateName
 }
 
 sealed interface DirectRegisterSideEffect {

--- a/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/viewmodel/ManualRegisterViewModel.kt
@@ -7,6 +7,7 @@ import com.obrit.obrit.shared.data.repository.ItemRepository
 import com.obrit.obrit.shared.model.categories.Category
 import com.obrit.obrit.shared.model.items.CreateItemParams
 import com.obrit.obrit.shared.model.items.ReplacementPeriod
+import com.obrit.obrit.shared.model.items.error.CreateItemError
 import org.orbitmvi.orbit.viewmodel.container
 
 class ManualRegisterViewModel(
@@ -43,7 +44,7 @@ class ManualRegisterViewModel(
 
     fun onNameChange(value: String) =
         intent {
-            reduce { state.copy(name = value) }
+            reduce { state.copy(name = value, isDuplicateName = false) }
         }
 
     fun onQuantityChange(value: Int) =
@@ -88,8 +89,13 @@ class ManualRegisterViewModel(
                     reduce { ManualRegisterUiState(categories = state.categories) }
                     postSideEffect(ManualRegisterSideEffect.OnRegistered)
                     loadCategories()
-                }.onFailure {
-                    reduce { state.copy(isSubmitting = false) }
+                }.onFailure { throwable ->
+                    reduce {
+                        state.copy(
+                            isSubmitting = false,
+                            isDuplicateName = throwable is CreateItemError.DuplicatedName,
+                        )
+                    }
                 }
         }
 
@@ -115,6 +121,7 @@ data class ManualRegisterUiState(
     val existingCount: Int = 0,
     val lastReplacementPeriod: ReplacementPeriod? = null,
     val isSubmitting: Boolean = false,
+    val isDuplicateName: Boolean = false,
 ) {
     val totalCount: Int
         get() = existingCount + quantity
@@ -125,7 +132,8 @@ data class ManualRegisterUiState(
                 name.isNotBlank() &&
                 lastReplacementPeriod != null &&
                 quantity > 0 &&
-                !isSubmitting
+                !isSubmitting &&
+                !isDuplicateName
 }
 
 sealed interface ManualRegisterSideEffect {

--- a/build-logic/src/main/kotlin/configurations/AndroidConfigurations.kt
+++ b/build-logic/src/main/kotlin/configurations/AndroidConfigurations.kt
@@ -31,6 +31,10 @@ internal fun Project.configureAndroidApplication() {
             getByName("release") {
                 isMinifyEnabled = false
             }
+            getByName("debug") {
+                applicationIdSuffix = ".debug"
+                versionNameSuffix = "-debug"
+            }
         }
 
         compileOptions {

--- a/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/CategoryRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/CategoryRepositoryImpl.kt
@@ -2,6 +2,8 @@ package com.obrit.obrit.shared.data.repository
 
 import com.obrit.obrit.shared.model.categories.Category
 import com.obrit.obrit.shared.model.categories.CategoryIcon
+import com.obrit.obrit.shared.model.categories.error.CreateCategoryError
+import com.obrit.obrit.shared.network.error.RemoteError
 import com.obrit.obrit.shared.network.error.runCatchingWith
 import com.obrit.obrit.shared.network.request.category.CreateCategoryRequest
 import com.obrit.obrit.shared.network.response.category.toCategory
@@ -30,6 +32,11 @@ internal class CategoryRepositoryImpl(
                         iconId = iconId,
                     ),
                 ).toCategory()
+        }.recoverCatching { error ->
+            if (error is RemoteError && error.statusCode == HTTP_STATUS_CONFLICT) {
+                throw CreateCategoryError.DuplicatedName()
+            }
+            throw error
         }
 
     override suspend fun deleteCategory(categoryId: Long): Result<Unit> =
@@ -43,4 +50,8 @@ internal class CategoryRepositoryImpl(
                 .getCategoryIcons()
                 .map { response -> response.toCategoryIcon() }
         }
+
+    private companion object {
+        const val HTTP_STATUS_CONFLICT = 409
+    }
 }

--- a/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/ItemRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/obrit/obrit/shared/data/repository/ItemRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.obrit.obrit.shared.model.items.CreateItemParams
 import com.obrit.obrit.shared.model.items.Item
 import com.obrit.obrit.shared.model.items.PatchItemParams
 import com.obrit.obrit.shared.model.items.ReplacementHistory
+import com.obrit.obrit.shared.model.items.error.CreateItemError
+import com.obrit.obrit.shared.network.error.RemoteError
 import com.obrit.obrit.shared.network.error.runCatchingWith
 import com.obrit.obrit.shared.network.request.item.BulkCreateItemRequest
 import com.obrit.obrit.shared.network.request.item.CreateItemRequest
@@ -28,6 +30,11 @@ internal class ItemRepositoryImpl(
             itemRemoteDataSource
                 .createItem(params.toCreateItemRequest())
                 .toItem()
+        }.recoverCatching { error ->
+            if (error is RemoteError && error.statusCode == HTTP_STATUS_CONFLICT) {
+                throw CreateItemError.DuplicatedName()
+            }
+            throw error
         }
 
     override suspend fun createItems(params: List<CreateItemParams>): Result<List<Item>> =
@@ -38,6 +45,11 @@ internal class ItemRepositoryImpl(
                         items = params.map { itemParams -> itemParams.toCreateItemRequest() },
                     ),
                 ).map { response -> response.toItem() }
+        }.recoverCatching { error ->
+            if (error is RemoteError && error.statusCode == HTTP_STATUS_CONFLICT) {
+                throw CreateItemError.DuplicatedName()
+            }
+            throw error
         }
 
     override suspend fun patchItem(params: PatchItemParams): Result<Item> =
@@ -99,6 +111,8 @@ internal class ItemRepositoryImpl(
                 ).toItem()
         }
 }
+
+private const val HTTP_STATUS_CONFLICT = 409
 
 private fun CreateItemParams.toCreateItemRequest() =
     CreateItemRequest(

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/categories/error/CreateCategoryError.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/categories/error/CreateCategoryError.kt
@@ -1,0 +1,11 @@
+package com.obrit.obrit.shared.model.categories.error
+
+import com.obrit.obrit.shared.model.RootError
+
+open class CreateCategoryError : RootError() {
+    // 서버가 409로만 구분하므로 errorCode는 사용하지 않고 repository에서 HTTP status로 매핑한다.
+    class DuplicatedName : CreateCategoryError()
+
+    override fun createErrorInstances(): Array<RootError> =
+        arrayOf(DuplicatedName())
+}

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/categories/error/CreateCategoryError.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/categories/error/CreateCategoryError.kt
@@ -6,6 +6,5 @@ open class CreateCategoryError : RootError() {
     // 서버가 409로만 구분하므로 errorCode는 사용하지 않고 repository에서 HTTP status로 매핑한다.
     class DuplicatedName : CreateCategoryError()
 
-    override fun createErrorInstances(): Array<RootError> =
-        arrayOf(DuplicatedName())
+    override fun createErrorInstances(): Array<RootError> = arrayOf(DuplicatedName())
 }

--- a/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/items/error/CreateItemError.kt
+++ b/shared/model/src/commonMain/kotlin/com/obrit/obrit/shared/model/items/error/CreateItemError.kt
@@ -1,0 +1,9 @@
+package com.obrit.obrit.shared.model.items.error
+
+import com.obrit.obrit.shared.model.RootError
+
+open class CreateItemError : RootError() {
+    class DuplicatedName : CreateItemError()
+
+    override fun createErrorInstances(): Array<RootError> = arrayOf(DuplicatedName())
+}


### PR DESCRIPTION
### 작업 요약

- 직접 등록 시 소모품 명/종류 이름이 중복(409)이면 입력 필드에 에러 메시지를 노출
- 디버그 빌드를 릴리스와 분리(패키지명/앱 이름)해 동시 설치 가능하도록 구성

### 관련 이슈

- #93 후속 작업

### 변경 사항

- `CreateItemError` / `CreateCategoryError` typed error 추가, repository에서 HTTP 409를 해당 에러로 매핑
- `ManualRegisterViewModel`에 `isDuplicateName` 상태 추가, 등록 실패 시 중복 에러 판별 및 CTA 비활성화
- `NameField`에 중복 이름 supporting text/에러 상태 표시
- 디버그 빌드 패키지명 분리 및 앱 이름 `OBRit (dev)` 적용

### 변경 이유

- 서버가 이름 중복을 409로만 응답하므로 사용자에게 원인을 명확히 안내하기 위함
- 디버그/릴리스 앱을 한 기기에 동시 설치해 검증 효율을 높이기 위함

### 영향 범위

- [x] 일반 기능 변경
- [x] UI 변경
- [x] API 연동 변경
- [ ] 공통 컴포넌트 변경
- [x] 시스템 영향 가능 (`lint`, `gradle`, `manifest`, build config 등)

> 디버그 빌드 패키지명/manifest 변경이 포함되어 있습니다.

### 리뷰 요청 포인트

- repository에서 409 → typed error 매핑 위치와 방식이 적절한지
- 디버그 빌드 분리 설정(패키지명/앱 이름)이 의도대로 동작하는지

### 테스트 / 검증

- [x] build 통과
- [x] ktlint 통과
- [x] detekt 통과
- [ ] unit test 통과
- [x] 수동 테스트 완료

### 체크리스트

- [x] 브랜치 네이밍 규칙 준수 (`feat/#이슈번호-기능명`)
- [x] 커밋 컨벤션 준수
- [x] PR 제목 = 커밋 컨벤션 형식
- [x] self-review 완료
- [ ] 문서 반영 필요 시 반영 완료
