### PR TITLE
fix: 온보딩 선택 화면 추가 소모품 개수 0으로 고정

### DIFF
--- a/android/feature/register/src/main/java/com/obrit/feature/register/screen/onboarding/OnboardingSelectScreenContent.kt
+++ b/android/feature/register/src/main/java/com/obrit/feature/register/screen/onboarding/OnboardingSelectScreenContent.kt
@@ -101,7 +101,7 @@ private fun OnboardingSelectBody(
                     OnboardingSelectCard(
                         name = category.name,
                         iconUrl = category.iconUrl,
-                        addedCount = category.itemCount,
+                        addedCount = 0,
                         selected = category.id in state.selectedIds,
                         onToggle = { onToggle(category.id) },
                     )


### PR DESCRIPTION
### 작업 요약

- 온보딩 Select 화면 카드의 "추가한 소모품 N개" 표시값을 0으로 고정한다.

### 관련 이슈

- #91

### 변경 사항

- `OnboardingSelectScreenContent.kt`: 카드의 `addedCount`를 `category.itemCount` → `0`으로 변경

### 변경 이유

- 온보딩은 앱의 사실상 첫 진입점이라 사용자가 아직 아무 소모품도 등록하지 않은 상태다. "추가한 소모품 N개" 정보가 현재로서 의미가 없어, 디자인을 들어내는 대신 표시값을 0으로 고정한다.
- 서버 전송값(`spareQuantity`)은 `OnboardingDetailViewModel.onSubmit()`에서 이미 `0`이라 변경하지 않았다.

### 영향 범위

- [x] UI 변경

### 테스트 / 검증

- [x] build 통과 (로컬 미실행)
- 온보딩 Select 화면 진입 시 모든 카테고리 카드가 "추가한 소모품 0개"로 표시되는지 확인 필요